### PR TITLE
multiple footers

### DIFF
--- a/templates/default/index.php
+++ b/templates/default/index.php
@@ -168,10 +168,8 @@ $themeColor = TemplateHelper::getThemeColour();
 				<?php endif ?>
 			</span>
 		<?php endif ?>
-	</footer>
-	<footer class="container-xl bg-dark text-light p-3 pt-1 text-light small" data-bs-theme="dark">
 		<div class="d-flex flex-column">
-			<p class="mb-2">
+			<p class="mt-3 mb-2">
 				<?= Text::sprintf('PANOPTICON_APP_LBL_COPYRIGHT', date('Y')) ?>
 			</p>
 			<p class="mb-2">


### PR DESCRIPTION
Technically the html5 spec allows you to have more than one footer landmark

but the a11y gurus as [deque](https://dequeuniversity.com/rules/axe/4.1/landmark-no-duplicate-contentinfo#:~:text=Interestingly%2C%20the%20HMTL5%20specification%20allows,specified%20using%20ARIA%20or%20HTML5.) says you shouldn't

This is a quick PR to merge the footers and to keep the spacing