### PR TITLE
basefontsize

### DIFF
--- a/src/Helper/DefaultTemplate.php
+++ b/src/Helper/DefaultTemplate.php
@@ -39,7 +39,7 @@ abstract class DefaultTemplate
 			return;
 		}
 
-		$container->application->getDocument()->addStyleDeclaration("body{font-size: {$baseFontSize}pt}");
+		$container->application->getDocument()->addStyleDeclaration("html{font-size: {$baseFontSize}pt}");
 	}
 
 	public static function getDarkMode(): DarkModeEnum


### PR DESCRIPTION
I spotted the font size option today in the configuration. I am **guessing** that the intention is to change the base font size. If I guessed correctly then its not working as you intended (last screenshot). This PR fixes that.

## Default Setting with no inline body style

![image](https://github.com/akeeba/panopticon/assets/1296369/08c2281b-9482-465d-afb1-f542175921f5)

## 14pt produces inline body{font-size: 14pt}

![image](https://github.com/akeeba/panopticon/assets/1296369/f4e0ccab-b372-4678-aefe-58e86521872d)

## 16pt produces inline body(font-size: 18pt)
![image](https://github.com/akeeba/panopticon/assets/1296369/a687d01a-66ec-48de-9147-a1d10742372c)

# What you intended inline html{font-size: 16pt}
![image](https://github.com/akeeba/panopticon/assets/1296369/6cb430de-fe33-43d0-a3f2-bf4bc391f0a1)
