### PR TITLE
php warnings

### DIFF
--- a/ViewTemplates/Main/php_warnings.blade.php
+++ b/ViewTemplates/Main/php_warnings.blade.php
@@ -28,49 +28,45 @@ if ($phpVersionInfo->unknown) return;
         </h3>
         <p>
             @sprintf(
-	            'PANOPTICON_MAIN_PHP_EOL_BODY',
-	            PHP_VERSION,
-	            $phpVersionInfo->dates->eol->format(\Awf\Text\Text::_('DATE_FORMAT_LC')),
-	            $phpVersion->getMinimumSupportedBranch(),
-	            $phpVersion->getRecommendedSupportedBranch()
+                'PANOPTICON_MAIN_PHP_EOL_BODY',
+                PHP_VERSION,
+                $phpVersionInfo->dates->eol->format(\Awf\Text\Text::_('DATE_FORMAT_LC')),
+                $phpVersion->getMinimumSupportedBranch(),
+                $phpVersion->getRecommendedSupportedBranch()
             )
         </p>
     </div>
 @elseif (!$phpVersionInfo->supported)
     <div class="alert alert-warning">
-        <h3 class="alert-heading h6 mb-0 pb-0"
-            data-bs-toggle="collapse" href="#phpWarningCollapse"
-            aria-expanded="false" aria-controls="phpWarningCollapse"
-            style="cursor: pointer"
-        >
-            <span class="fa fa-exclamation-triangle" aria-hidden="true"></span>
-            @sprintf('PANOPTICON_MAIN_PHP_SECURITY_HEAD', PHP_VERSION)
-        </h3>
-        <p class="collapse mb-0 mt-2 pb-0" id="phpWarningCollapse">
-            @sprintf(
-	            'PANOPTICON_MAIN_PHP_SECURITY_BODY',
-	            PHP_VERSION,
-	            $phpVersionInfo->dates->eol->format(\Awf\Text\Text::_('DATE_FORMAT_LC')),
-	            $phpVersion->getRecommendedSupportedBranch()
-            )
-        </p>
+        <details>
+            <summary>
+                <span class="fa fa-exclamation-triangle" aria-hidden="true"></span>
+                @sprintf('PANOPTICON_MAIN_PHP_SECURITY_HEAD', PHP_VERSION)
+            </summary>
+            <p>
+                @sprintf(
+                    'PANOPTICON_MAIN_PHP_SECURITY_BODY',
+                    PHP_VERSION,
+                    $phpVersionInfo->dates->eol->format(\Awf\Text\Text::_('DATE_FORMAT_LC')),
+                    $phpVersion->getRecommendedSupportedBranch()
+                )
+                </p>
+        </details>
     </div>
 @elseif (version_compare(PHP_VERSION, $phpVersionInfo->latest, 'lt'))
     <div class="alert alert-info">
-        <h3 class="alert-heading h6 mb-1"
-            data-bs-toggle="collapse" href="#phpWarningCollapse"
-            aria-expanded="false" aria-controls="phpWarningCollapse"
-            style="cursor: pointer"
-        >
-            <span class="fa fa-circle-info" aria-hidden="true"></span>
-            @lang('PANOPTICON_MAIN_PHP_UPDATE_HEAD')
-        </h3>
-        <p class="collapse mb-0 mt-2 pb-0" id="phpWarningCollapse">
-            @sprintf(
-	            'PANOPTICON_MAIN_PHP_UPDATE_BODY',
-	            PHP_VERSION,
-	            $phpVersionInfo->latest
-            )
-        </p>
+        <details>
+            <summary class="text-info">
+                <span class="fa fa-info-circle" aria-hidden="true"></span>
+                @lang('PANOPTICON_MAIN_PHP_UPDATE_HEAD')
+            </summary>
+            <p>
+                @sprintf(
+                    'PANOPTICON_MAIN_PHP_UPDATE_BODY',
+                    PHP_VERSION,
+                    $phpVersionInfo->latest
+                )
+            </p>
+        </details>
     </div>
 @endif


### PR DESCRIPTION
This converts the warnings for php security and php not up to date from the horrible bs-collapse to use the native details/summary which is used elsewhere and accessible by default.

This has the bonus that it is much clearer now that you can click to expand and you dont have to use inline css to change the pointer.

I left the php eol message as is because that is justy displayed without a disclosure element.

## before
![image](https://github.com/akeeba/panopticon/assets/1296369/638ed901-870f-4dca-805a-6ac2b07a2ac0)

![image](https://github.com/akeeba/panopticon/assets/1296369/6f47d7b4-5f61-4d12-afee-23d35ca0a10b)

## after
![image](https://github.com/akeeba/panopticon/assets/1296369/84e68c13-baf1-47fe-9b90-8f2fa2bca9e4)

![image](https://github.com/akeeba/panopticon/assets/1296369/43e65ec7-cc15-4c85-a8e9-331bc6ea157b)
