### PR TITLE
Accessibility - unique links

### DIFF
--- a/ViewTemplates/Main/site_extensions.blade.php
+++ b/ViewTemplates/Main/site_extensions.blade.php
@@ -44,10 +44,10 @@ $numKeyMissing = array_reduce(
 		<a type="button" class="btn btn-outline-secondary btn-sm" role="button"
 		   href="@route(sprintf('index.php?view=site&task=refreshExtensionsInformation&id=%d&return=%s&%s=1', $item->id, base64_encode(\Awf\Uri\Uri::getInstance()->toString()), $this->container->session->getCsrfToken()->getValue()))"
 		   data-bs-toggle="tooltip" data-bs-placement="bottom"
-		   data-bs-title="@lang('PANOPTICON_SITE_BTN_EXTENSIONS_RELOAD')"
+		   data-bs-title="@sprintf('PANOPTICON_SITE_BTN_EXTENSIONS_RELOAD', $item->name)"
 		>
 			<span class="fa fa-refresh" aria-hidden="true"></span>
-			<span class="visually-hidden">@lang('PANOPTICON_SITE_BTN_EXTENSIONS_RELOAD')</span>
+			<span class="visually-hidden">@sprintf('PANOPTICON_SITE_BTN_EXTENSIONS_RELOAD', $item->name)</span>
 		</a>
 	</div>
 	<div class="d-flex flex-column flex-md-row gap-2">

--- a/ViewTemplates/Main/site_joomla.blade.php
+++ b/ViewTemplates/Main/site_joomla.blade.php
@@ -66,10 +66,10 @@ $returnUrl           = base64_encode(\Awf\Uri\Uri::getInstance()->toString());
     <a class="btn btn-sm btn-outline-secondary" role="button"
        href="@route(sprintf('index.php?view=site&task=refreshSiteInformation&id=%d&return=%s&%s=1', $item->id, $returnUrl, $token))"
        data-bs-toggle="tooltip" data-bs-placement="bottom"
-       data-bs-title="@lang('PANOPTICON_SITE_BTN_JUPDATE_RELOAD')"
+       data-bs-title="@sprintf('PANOPTICON_SITE_BTN_JUPDATE_RELOAD', $item->name)"
     >
         <span class="fa fa-refresh" aria-hidden="true"></span>
-        <span class="visually-hidden">@lang('PANOPTICON_SITE_BTN_JUPDATE_RELOAD')</span>
+        <span class="visually-hidden">@sprintf('PANOPTICON_SITE_BTN_JUPDATE_RELOAD', $item->name)</span>
     </a>
     {{-- Is Joomla Update working at all? --}}
     @if($jUpdateFailure)

--- a/languages/en-GB.ini
+++ b/languages/en-GB.ini
@@ -601,7 +601,7 @@ PANOPTICON_SITE_ERR_JUPDATE_SCHEDULE_FAILED=Scheduling the Joomla core update ha
 PANOPTICON_SITE_LBL_JUPDATE_SCHEDULE_ERROR_CLEARED=The scheduling error has been cleared.
 PANOPTICON_SITE_LBL_JUPDATE_SCHEDULE_ERROR_NOT_CLEARED=The scheduling error could not be cleared: %s
 PANOPTICON_SITE_LBL_JUPDATE_HEAD=Joomla!™ Update
-PANOPTICON_SITE_BTN_JUPDATE_RELOAD=Reload Joomla!™ Update information
+PANOPTICON_SITE_BTN_JUPDATE_RELOAD=Reload Joomla!™ Update information: %s
 PANOPTICON_SITE_LBL_JUPDATE_LAST_CHECKED=Last checked:
 PANOPTICON_SITE_LBL_JUPDATE_ERR_JOOMLA_FILES_EXT_MISSING=The Joomla! extension record is missing from your site. Joomla! cannot detect whether updates to itself are available.
 PANOPTICON_SITE_LBL_JUPDATE_SEEK_HELP_JFORUM=Try asking for help on the <a href="https://forum.joomla.org" target="_blank">Joomla! Forum</a>.
@@ -645,7 +645,7 @@ PANOPTICON_SITE_LBL_EXTENSION_UPDATE_RUNNING=Automatic extension updates are in 
 PANOPTICON_SITE_LBL_EXTENSION_UPDATE_ERRORED=Automatic extension updates ran into an error:
 PANOPTICON_SITE_LBL_PHP_HEAD=PHP
 PANOPTICON_SITE_BTN_PHP_RELOAD=Reload PHP Information
-PANOPTICON_SITE_BTN_EXTENSIONS_RELOAD=Reload Extensions Information
+PANOPTICON_SITE_BTN_EXTENSIONS_RELOAD=Reload Extensions Information: %s
 PANOPTICON_SITE_LBL_PHP_UNKNOWN=Unknown PHP %s
 PANOPTICON_SITE_LBL_PHP_UNKNOWN_INFO=Your version of PHP is not known to Panopticon. Try clearing the <code>cache</code> folder.
 PANOPTICON_SITE_LBL_PHP_EOL=End-of-Life PHP %s


### PR DESCRIPTION
This PR is an example - you will probably want to check for other similar instances.

Multiple links with the same text that go to different places is no good for users who are navigating a site with a screen reader especially when they are in an nvda (or similar) elements list 

![image](https://github.com/akeeba/panopticon/assets/1296369/a7d1b935-c2a4-4cec-937f-4765f94e906d)

![image](https://github.com/akeeba/panopticon/assets/1296369/d56277d3-1e4e-4e9c-bbc2-aa34b447f674)
