### PR TITLE
em-dash

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -679,7 +679,7 @@ Notwithstanding your rights under the fair use doctrine or equivalent laws, the 
 
 4. Restrictions on advertising and commercial usage of the names, logos, and wordmarks
 
-You are disallowed from using the “Akeeba” name, logo, and wordmark, the “Akeeba Panopticon” name, and logo, and the “Panopticon” name for advertising and commercial purposes —including but not limited to advertising campaigns (printed, electronic, or otherwise), web site banners, web site copy, and social media posts— in a way which asserts, implies, or could reasonably be misconstrued as endorsement of your person, business, or product by the licensors and authors of this material. You are permitted to use the aforementioned copyrighted items under the fair use doctrine for factual statements such as “This service makes use of Akeeba Panopticon, a self-hosted site monitoring software created and distributed by Akeeba Ltd”.
+You are disallowed from using the “Akeeba” name, logo, and wordmark, the “Akeeba Panopticon” name, and logo, and the “Panopticon” name for advertising and commercial purposes -including but not limited to advertising campaigns (printed, electronic, or otherwise), web site banners, web site copy, and social media posts— in a way which asserts, implies, or could reasonably be misconstrued as endorsement of your person, business, or product by the licensors and authors of this material. You are permitted to use the aforementioned copyrighted items under the fair use doctrine for factual statements such as “This service makes use of Akeeba Panopticon, a self-hosted site monitoring software created and distributed by Akeeba Ltd”.
 
 5. Non-transferability of liability and indemnification
 

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -679,7 +679,7 @@ Notwithstanding your rights under the fair use doctrine or equivalent laws, the 
 
 4. Restrictions on advertising and commercial usage of the names, logos, and wordmarks
 
-You are disallowed from using the “Akeeba” name, logo, and wordmark, the “Akeeba Panopticon” name, and logo, and the “Panopticon” name for advertising and commercial purposes -including but not limited to advertising campaigns (printed, electronic, or otherwise), web site banners, web site copy, and social media posts— in a way which asserts, implies, or could reasonably be misconstrued as endorsement of your person, business, or product by the licensors and authors of this material. You are permitted to use the aforementioned copyrighted items under the fair use doctrine for factual statements such as “This service makes use of Akeeba Panopticon, a self-hosted site monitoring software created and distributed by Akeeba Ltd”.
+You are disallowed from using the “Akeeba” name, logo, and wordmark, the “Akeeba Panopticon” name, and logo, and the “Panopticon” name for advertising and commercial purposes - including but not limited to advertising campaigns (printed, electronic, or otherwise), web site banners, web site copy, and social media posts— in a way which asserts, implies, or could reasonably be misconstrued as endorsement of your person, business, or product by the licensors and authors of this material. You are permitted to use the aforementioned copyrighted items under the fair use doctrine for factual statements such as “This service makes use of Akeeba Panopticon, a self-hosted site monitoring software created and distributed by Akeeba Ltd”.
 
 5. Non-transferability of liability and indemnification
 

--- a/TODO.md
+++ b/TODO.md
@@ -94,7 +94,7 @@ The `operator` user can only see the `Main Site`. They can also execute updates 
 
 The `secretary` user can only see the `Main Site`. They can neither edit its configuration, nor execute updates on it.
 
-**Your takeaway**: By creating appropriate groups and assigning them to your users and sites, you can give your clients' staff access to the Panopticon pages for their sites. You are not exposing your other clients' sites to them — Panopticon remains mum about these other sites to these users. By varying the per-group privileges you can prevent your clients from carrying out potentially problematic operations on their sites in Panopticon.
+**Your takeaway**: By creating appropriate groups and assigning them to your users and sites, you can give your clients' staff access to the Panopticon pages for their sites. You are not exposing your other clients' sites to them - Panopticon remains mum about these other sites to these users. By varying the per-group privileges you can prevent your clients from carrying out potentially problematic operations on their sites in Panopticon.
 
 ## Why no uptime monitoring
 

--- a/ViewTemplates/About/default_license.blade.php
+++ b/ViewTemplates/About/default_license.blade.php
@@ -16,7 +16,7 @@ $copyrightYear = ($maxYear == 2023) ? "2023" : "2023–{$maxYear}";
 <h4>@lang('PANOPTICON_ABOUT_LBL_LICENSE')</h4>
 
 <p>
-    @lang('PANOPTICON_APP_TITLE') — @lang('PANOPTICON_ABOUT_LBL_APP_SUBTITLE').
+    @lang('PANOPTICON_APP_TITLE') - @lang('PANOPTICON_ABOUT_LBL_APP_SUBTITLE').
     <br />
     @sprintf('PANOPTICON_ABOUT_LBL_COPYRIGHT', $copyrightYear)
 </p>

--- a/htaccess.txt
+++ b/htaccess.txt
@@ -173,7 +173,7 @@
 ServerSignature Off
 
 ### ============================================================================
-### HSTS — For HTTPS–only sites
+### HSTS - For HTTPS–only sites
 ### ============================================================================
 ## Remove if your server does not run under HTTPS (WHY?!!!!)
 <IfModule mod_headers.c>

--- a/languages/en-GB.ini
+++ b/languages/en-GB.ini
@@ -268,7 +268,7 @@ PANOPTICON_SETUP_LBL_REC_OUTBUF=Output Buffering
 PANOPTICON_SETUP_LBL_REC_SESSIONAUTO=Session Auto Start
 PANOPTICON_SETUP_LBL_REC_FTP=PHP FTP Extension
 PANOPTICON_SETUP_LBL_REC_SSH2=SFTP Support
-PANOPTICON_SETUP_LBL_DATABASE_HEAD_TEXT=Panopticon needs a database to work. First, create a database —and a database user— on your server. Then enter the connection information to the database below. If something is unclear please check with the company hosting your site.
+PANOPTICON_SETUP_LBL_DATABASE_HEAD_TEXT=Panopticon needs a database to work. First, create a database - and a database user - on your server. Then enter the connection information to the database below. If something is unclear please check with the company hosting your site.
 PANOPTICON_SETUP_LBL_DATABASE_DRIVER=Database type
 PANOPTICON_SETUP_LBL_DATABASE_DRIVER_HELP=This is usually MySQLi (<em>with</em> the trailing \"i\")
 PANOPTICON_SETUP_LBL_DATABASE_DRIVER_MYSQL=MySQL (obsolete driver for MySQL - avoid using)
@@ -385,7 +385,7 @@ PANOPTICON_SETUP_LBL_CRON_TROUBLE_URL_CRON_HEAD=The host only allows URLs in CRO
 PANOPTICON_SETUP_LBL_CRON_TROUBLE_URL_CRON_INFO=Click on the <strong>Web</strong> tab above.
 PANOPTICON_SETUP_LBL_CRON_TROUBLE_NO_CRON_HEAD=The host does not have a CRON feature
 PANOPTICON_SETUP_LBL_CRON_TROUBLE_NO_CRON_INFO_1=We <strong>very strongly</strong> recommend that you use a different host.
-PANOPTICON_SETUP_LBL_CRON_TROUBLE_NO_CRON_INFO_2="Panopticon is only useful when its automation features run consistently and reliably. This requires its CRON job executing every minute — <em>1440 times a day</em>. This can get expensive with a third party service; about $10 per day! You can instead spend as much money <em>per month</em> on a decent host which support real, command-line CRON jobs."
+PANOPTICON_SETUP_LBL_CRON_TROUBLE_NO_CRON_INFO_2="Panopticon is only useful when its automation features run consistently and reliably. This requires its CRON job executing every minute - <em>1440 times a day</em>. This can get expensive with a third party service; about $10 per day! You can instead spend as much money <em>per month</em> on a decent host which support real, command-line CRON jobs."
 PANOPTICON_SETUP_LBL_CRON_TROUBLE_NO_CRON_INFO_3=If you have a cheaper way executing CRON jobs remotely (e.g. another server under your control), please click on the <strong>Web</strong> tab to find out how to do it.
 PANOPTICON_SETUP_LBL_CRON_TROUBLE_NO_CRON_INFO_4=<strong>Do not “cheap out” on CRON job frequency!</strong> Running CRON jobs less frequently will make Panopticon unreliable and could even break your sites due to incomplete Joomla™ core updates.
 PANOPTICON_SETUP_LBL_CRON_CLI_PROS_1=More reliable
@@ -411,8 +411,8 @@ PANOPTICON_SETUP_LBL_CRON_WEB_TARGET_1=Servers with URL-only CRON jobs
 PANOPTICON_SETUP_LBL_CRON_WEB_TARGET_2=Ten or fewer monitored sites
 PANOPTICON_SETUP_LBL_CRON_WHAT_NEXT=What next?
 PANOPTICON_SETUP_LBL_CRON_WHAT_NEXT_BENCHMARK_INFO=A few seconds to a minute after you set up your CRON job this page will change to a benchmark. Don't close this browser tab, don't change to a different browser tab / window or application, don't turn off or let your device sleep, don't feed your <em title=\"These are the gremlins before they become gremlins. Are we showing our age with this outdated popular culture reference?\">mogwai</em> after midnight. Pretty straightforward, right?
-PANOPTICON_SETUP_LBL_CRON_WHAT_NEXT_YOU_CAN_COME_BACK_LATER=If you need to finish setting up your CRON job later — no worries! Close this browser tab. Next time you come back to your Panopticon installation it will take you to this page.
-PANOPTICON_SETUP_LBL_CRON_WHAT_NEXT_EXPERT_USER=If you're an expert user —or just looking around— you can skip this step and set up CRON jobs later.
+PANOPTICON_SETUP_LBL_CRON_WHAT_NEXT_YOU_CAN_COME_BACK_LATER=If you need to finish setting up your CRON job later - no worries! Close this browser tab. Next time you come back to your Panopticon installation it will take you to this page.
+PANOPTICON_SETUP_LBL_CRON_WHAT_NEXT_EXPERT_USER=If you're an expert user - or just looking around - you can skip this step and set up CRON jobs later.
 PANOPTICON_SETUP_LBL_CRON_WHAT_NEXT_SKIP_CRON=Skip CRON configuration (not recommended).
 PANOPTICON_SETUP_LBL_CRON_BENCHMARK_IN_PROGRESS=Benchmark in progress
 PANOPTICON_SETUP_LBL_CRON_BENCHMARK_WHAT_IS_THIS=Panopticon is measuring how long a CRON task can run
@@ -678,7 +678,7 @@ PANOPTICON_SITE_LBL_PHP_EOL_INFO=PHP %s reached its End-of-Life on %s. You shoul
 PANOPTICON_SITE_LBL_PHP_LTS_HEAD=Note about “long term support” Linux distributions
 PANOPTICON_SITE_LBL_PHP_LTS_P1=Some Linux Distributions, such as RedHat Enterprise Linux and Ubuntu Server, may offer “long term support” for certain PHP versions past their End of Life date.
 PANOPTICON_SITE_LBL_PHP_LTS_P2=Please note that this typically requires an additional, often expensive, per-server license. Moreover, some security fixes which require changes in the internal PHP architecture cannot be applied in these old PHP versions. Finally, functional issues (‘bugs’) and compatibility with newer Internet standards and best practices are <em>never</em> addressed.
-PANOPTICON_SITE_LBL_PHP_LTS_P3=While these Long Term Support distributions are useful for specific use cases —such as company intranets and extranets— they are ultimately not suitable for long term use on a publicly accessible website. We strongly recommend installing and using one of the actively supported PHP branches (currently, PHP versions %s and %s).
+PANOPTICON_SITE_LBL_PHP_LTS_P3=While these Long Term Support distributions are useful for specific use cases - such as company intranets and extranets - they are ultimately not suitable for long term use on a publicly accessible website. We strongly recommend installing and using one of the actively supported PHP branches (currently, PHP versions %s and %s).
 PANOPTICON_SITE_LBL_PHP_PHP=PHP %s
 PANOPTICON_SITE_LBL_WHERE_DID_I_GET_DATA="Where did I get this data from?"
 PANOPTICON_SITE_LBL_PHP_UPDATE_AVAILABLE=The latest PHP %s version is %s. You need to update PHP on your server.
@@ -811,8 +811,8 @@ PANOPTICON_SITES_LBL_AKEEBABACKUP_LATEST=Latest Backups
 
 PANOPTICON_SITES_LBL_TROUBLESHOOT_HEAD="Troubleshooting Information"
 PANOPTICON_SITES_LBL_TROUBLESHOOT_API403_HEAD="The Joomla! API Application is blocked (HTTP error 403)"
-PANOPTICON_SITES_LBL_TROUBLESHOOT_API403_WHATIS="Something on your server —such as the server configuration controlled by your host, a server configuration file such as <code>.htaccess</code>, or a plugin of your site— is blocking Panopticon from accessing your site's API application (<span class=\"font-monospace\">%s</span>)."
-PANOPTICON_SITES_LBL_TROUBLESHOOT_API403_WHATIS_J3="Something on your server —such as the server configuration controlled by your host, a server configuration file such as <code>.htaccess</code>, or a plugin of your site— is blocking Panopticon from accessing the URL of the API plugin (<span class=\"font-monospace\">%s</span>) on your site."
+PANOPTICON_SITES_LBL_TROUBLESHOOT_API403_WHATIS="Something on your server - such as the server configuration controlled by your host, a server configuration file such as <code>.htaccess</code>, or a plugin of your site - is blocking Panopticon from accessing your site's API application (<span class=\"font-monospace\">%s</span>)."
+PANOPTICON_SITES_LBL_TROUBLESHOOT_API403_WHATIS_J3="Something on your server - such as the server configuration controlled by your host, a server configuration file such as <code>.htaccess</code>, or a plugin of your site - is blocking Panopticon from accessing the URL of the API plugin (<span class=\"font-monospace\">%s</span>) on your site."
 PANOPTICON_SITES_LBL_TROUBLESHOOT_API403_TOCHECK="Things to check:"
 PANOPTICON_SITES_LBL_TROUBLESHOOT_API403_CHECK1="Does your host, or your server configuration file (e.g. <code>.htaccess</code>), block access to the Joomla! API Application endpoint (<span class=\"font-monospace\">%s</span>) altogether?"
 PANOPTICON_SITES_LBL_TROUBLESHOOT_API403_CHECK1_J3="Does your host, or your server configuration file (e.g. <code>.htaccess</code>), block access to the API plugin endpoint (<span class=\"font-monospace\">%s</span>) altogether?"
@@ -844,7 +844,7 @@ PANOPTICON_SITES_LBL_TROUBLESHOOT_APITOKEN_BLAH3="It is also possible that somet
 PANOPTICON_SITES_LBL_TROUBLESHOOT_APITOKEN_BLAH4="Please check your installed Joomla! plugins. Kindly note that no, Admin Tools Professional for Joomla! <em>does not</em> interfere with the Joomla! API Token. If this does not help please contact your host."
 PANOPTICON_SITES_LBL_TROUBLESHOOT_CURL_HEAD="There was a communication error with your site."
 PANOPTICON_SITES_LBL_TROUBLESHOOT_CURL_BLAH1="The communication library used by PHP (cURL) has reported the following error:"
-PANOPTICON_SITES_LBL_TROUBLESHOOT_CURL_BLAH2="Please consult the <a href=\"https://curl.se/libcurl/c/libcurl-errors.html\" target=\"_blank\">cURL library error code reference</a> for more information about the error. In most cases the problem is a network or server configuration issue —either the server you have installed Panopticon on, or the server your Joomla! site is on— which requires contacting the respective host to help you address."
+PANOPTICON_SITES_LBL_TROUBLESHOOT_CURL_BLAH2="Please consult the <a href=\"https://curl.se/libcurl/c/libcurl-errors.html\" target=\"_blank\">cURL library error code reference</a> for more information about the error. In most cases the problem is a network or server configuration issue - either the server you have installed Panopticon on, or the server your Joomla! site is on - which requires contacting the respective host to help you address."
 PANOPTICON_SITES_LBL_TROUBLESHOOT_GUZZLE_HEAD="There was a communication error with your site."
 PANOPTICON_SITES_LBL_TROUBLESHOOT_GUZZLE_BLAH1="The communication library used by Panopticon (<a href=\"https://github.com/guzzle/guzzle\" target=\"_blank\">Guzzle HTTP</a>) has reported the following error:"
 PANOPTICON_SITES_LBL_TROUBLESHOOT_GUZZLE_BLAH2="This is an unexpected condition which may indicate a communication error we have not yet seen, a problem within Guzzle itself, a problem with the server you have installed Panopticon on, or a problem in Panopticon itself. Please search the open <em>and closed</em> issues <a href=\"https://github.com/akeeba/panopticon/issues?q=is%3Aissue\" target=\"_blank\">on our GitHub repository</a>. If nobody else has reported this, please open an issue and we will take a look."
@@ -852,7 +852,7 @@ PANOPTICON_SITES_LBL_TROUBLESHOOT_DNS_HEAD="The host name of your site (<span cl
 PANOPTICON_SITES_LBL_TROUBLESHOOT_DNS_CHECK="Please check the following:"
 PANOPTICON_SITES_LBL_TROUBLESHOOT_DNS_CHECK1="Have you typed the URL correctly? Check carefully, misspellings are easy to make and hard to catch!"
 PANOPTICON_SITES_LBL_TROUBLESHOOT_DNS_CHECK2="Have you recently bought the domain, assigned the domain to a server, or transferred your site between hosts? Keep in mind that DNS propagation takes anywhere from 5 minutes to several days. Moreover, due to the distributed nature of DNS, it is possible that you can see your site <em>from your device</em> but the server you have installed Panopticon on can't."
-PANOPTICON_SITES_LBL_TROUBLESHOOT_DNS_CHECK3="If your site's domain resolves to an IPv6 address —but not an IPv4 address— make sure that the server you have installed Panopticon on supports IPv6. You may have to ask your host to confirm that this is the case."
+PANOPTICON_SITES_LBL_TROUBLESHOOT_DNS_CHECK3="If your site's domain resolves to an IPv6 address - but not an IPv4 address - make sure that the server you have installed Panopticon on supports IPv6. You may have to ask your host to confirm that this is the case."
 PANOPTICON_SITES_LBL_TROUBLESHOOT_CONNECTOR_HEAD="The Akeeba Panopticon Connector is not enabled on your site"
 PANOPTICON_SITES_LBL_TROUBLESHOOT_CONNECTOR_BLAH="Your Joomla! site needs to have the Akeeba Panopticon Connector installed and enabled for Akeeba Panopticon to work with it."
 PANOPTICON_SITES_LBL_TROUBLESHOOT_CONNECTOR_CHECK="Please check the following:"
@@ -874,7 +874,7 @@ PANOPTICON_SITES_LBL_TROUBLESHOOT_TLSBORKED_CHECK="Please check the following:"
 PANOPTICON_SITES_LBL_TROUBLESHOOT_TLSBORKED_CHECK1="Is the SSL/TLS certificate for the right domain name? If you are using the default SSL/TLS certificate provided by your host it is limited to the temporary domain name you use to set up your site, not your real domain name. You will need to install an SSL/TLS certificate signed by a commercial, well-known Certification Authority. Most servers allow you to use <a href=\"https://en.wikipedia.org/wiki/Let%27s_Encrypt\" target=\"_blank\">Let's Encrypt</a> which issues valid, signed, fully working SSL/TLS certificates free of charge. Remember that some self-service hosting control panels (such as cPanel, or Plesk) allow you to select which is the active SSL/TLS certificate for a domain name. Do check that the correct certificate is, indeed, being used."
 PANOPTICON_SITES_LBL_TROUBLESHOOT_TLSBORKED_CHECK2="Has the SSL/TLS certificate expired? In this case you need to renew it. Please note that if you are using Let's Encrypt the certificate has a short validity period (usually 90 days) and it should be renewed automatically by your host. If this did not happen, you will need to contact your host."
 PANOPTICON_SITES_LBL_TROUBLESHOOT_TLSBORKED_CHECK3="Has the SSL/TLS certificate been revoked? Sometimes Certification Authorities, or the owners of an SSL/TLS certificate, may choose to revoke it. For example, Certification Authorities will do that if they suspect fraud, or if they believe their infrastructure used to issue a certificate was compromised. <a href=\"https://www.namecheap.com/support/knowledgebase/article.aspx/9968/38/how-to-check-the-certificate-revocation-status/\" target=\"_blank\">Check your certificate's revocation status</a>. If it's been revoked you will need a new certificate."
-PANOPTICON_SITES_LBL_TROUBLESHOOT_TLSBORKED_CHECK4="Is it possible that your server serves the wrong SSL/TLS certificate? This may happen if you have recently switched to a new certificate, either manually or as part of an automated certificate rotation process (e.g. when your host issues a new certificate through Let's Encrypt). When the certificate changes the web server needs to be reloaded or restarted. In some rare cases this might not happen — or an inexperienced systems administrator may forget to do it. Please contact your host / systems administrator to check that and, if necessary, reload or restart the web server process."
+PANOPTICON_SITES_LBL_TROUBLESHOOT_TLSBORKED_CHECK4="Is it possible that your server serves the wrong SSL/TLS certificate? This may happen if you have recently switched to a new certificate, either manually or as part of an automated certificate rotation process (e.g. when your host issues a new certificate through Let's Encrypt). When the certificate changes the web server needs to be reloaded or restarted. In some rare cases this might not happen - or an inexperienced systems administrator may forget to do it. Please contact your host / systems administrator to check that and, if necessary, reload or restart the web server process."
 PANOPTICON_SITES_LBL_TROUBLESHOOT_WEBSERVICES_HEAD="The “Web Services - Installer” plugin is disabled on your site"
 PANOPTICON_SITES_LBL_TROUBLESHOOT_WEBSERVICES_BLAH1="Panopticon uses the Joomla! API Application services provided by the “Web Services - Installer” plugin to ensure that all necessary extensions are installed and published on your site."
 PANOPTICON_SITES_LBL_TROUBLESHOOT_WEBSERVICES_BLAH2="Please go to your site's backend and click on System, Manage, Extensions. Search for the “Web Services - Installer” plugin and enable it."
@@ -920,7 +920,7 @@ PANOPTICON_SYSCONFIG_LBL_SUBHEAD_PROXY=Proxy Server
 PANOPTICON_SYSCONFIG_LBL_SUBHEAD_SITE_INFO=Collecting Site Information
 PANOPTICON_SYSCONFIG_LBL_SUBHEAD_SYSTEM=System Preferences
 PANOPTICON_SYSCONFIG_NO_EXTENSIONS_HEAD=No extensions found
-PANOPTICON_SYSCONFIG_NO_EXTENSIONS_BODY=Set up your sites and wait until their extension update information refreshes — up to 15 minutes later. You will then see all of their installed extensions here.
+PANOPTICON_SYSCONFIG_NO_EXTENSIONS_BODY=Set up your sites and wait until their extension update information refreshes - up to 15 minutes later. You will then see all of their installed extensions here.
 PANOPTICON_SYSCONFIG_LBL_FIELD_LIVE_SITE=Panopticon URL
 PANOPTICON_SYSCONFIG_LBL_FIELD_LIVE_SITE_HELP=The base URL of your Panopticon installation. Used when sending email from unattended tasks.
 PANOPTICON_SYSCONFIG_LBL_FIELD_SESSION_TIMEOUT=Session Timeout
@@ -1083,7 +1083,7 @@ PANOPTICON_LBL_MAILTEMPLATE_SAVED=The Mail Template has been saved
 PANOPTICON_LBL_MAILTEMPLATE_COPIED=The selected Mail Templates have been copied
 PANOPTICON_LBL_MAILTEMPLATE_DELETED=The selected Mail Templates have been deleted
 PANOPTICON_MAILTEMPLATES_OPT_LANGUAGE_ALL=(All)
-PANOPTICON_MAILTEMPLATES_OPT_TYPE_MUST_SELECT=— Select an option —
+PANOPTICON_MAILTEMPLATES_OPT_TYPE_MUST_SELECT=- Select an option -
 PANOPTICON_MAILTEMPLATES_OPT_TYPE_JOOMLAUPDATE_FOUND=Joomla Core Update: Update found
 PANOPTICON_MAILTEMPLATES_OPT_TYPE_JOOMLAUPDATE_WILL_INSTALL=Joomla Core Update: Update will be installed
 PANOPTICON_MAILTEMPLATES_OPT_TYPE_JOOMLAUPDATE_INSTALLED=Joomla Core Update: Update installed
@@ -1175,7 +1175,7 @@ PANOPTICON_ABOUT_LBL_APP_SUBTITLE=Self–hosted site monitoring
 PANOPTICON_ABOUT_LBL_COPYRIGHT="Copyright &copy; %s Akeeba Ltd"
 PANOPTICON_ABOUT_LBL_PLEASE_READ_LICENSE="For the complete text of the software license, please read the <a class=\"text-body-tertiary\" href=\"%sLICENSE.txt\">LICENSE.txt</a> file supplied with the software."
 PANOPTICON_ABOUT_LBL_3PD_SOFTWARE=Third Party Software Included
-PANOPTICON_ABOUT_LBL_3PD_SOFTWARE_ABOUT="Software is not made in a vacuum, or by virgin birth. We build upon the work of other people and organisations who have kindly provided their software libraries under a permissive license. Below, you can find the third party software which is included in Akeeba Panopticon, its version numbers, and its integrity checksum — essentially a Software Bill Of Materials (SBOM) which you might need for compliance reasons."
+PANOPTICON_ABOUT_LBL_3PD_SOFTWARE_ABOUT="Software is not made in a vacuum, or by virgin birth. We build upon the work of other people and organisations who have kindly provided their software libraries under a permissive license. Below, you can find the third party software which is included in Akeeba Panopticon, its version numbers, and its integrity checksum - essentially a Software Bill Of Materials (SBOM) which you might need for compliance reasons."
 PANOPTICON_ABOUT_LBL_PHP_DEPS=PHP Dependencies
 PANOPTICON_ABOUT_LBL_PACKAGE=Package
 PANOPTICON_ABOUT_LBL_VERSION=Version
@@ -1310,7 +1310,7 @@ PANOPTICON_MFA_LBL_BACKUPCODES_RESET_INFO=Use the “Regenerate Backup Codes” 
 PANOPTICON_MFA_LBL_BACKUPCODES_ENTRY_LABEL=Your emergency backup code
 PANOPTICON_MFA_LBL_BACKUPCODES_USE_WHEN_LOCKED_OUT=Enter an emergency backup code if you are locked out.
 PANOPTICON_MFA_FIXED_LBL_DISPLAYEDAS=Fixed Code
-PANOPTICON_MFA_FIXED_LBL_SHORTINFO=Choose your own preset code, essentially a second password. <strong>For demonstration purposes only — this is disabled in production</strong>.
+PANOPTICON_MFA_FIXED_LBL_SHORTINFO=Choose your own preset code, essentially a second password. <strong>For demonstration purposes only - this is disabled in production</strong>.
 PANOPTICON_MFA_FIXED_LBL_LABEL=Enter your fixed Multi-factor Authentication code
 PANOPTICON_MFA_FIXED_LBL_PLACEHOLDER=Enter your Fixed Code
 PANOPTICON_MFA_FIXED_LBL_PREMESSAGE=<p>This is a demonstration Multi-factor Authentication plugin for Panopticon. You need to enter the fixed code you configured when enabling the Multi-factor Authentication for this user. It effectively works as a second password.</p>

--- a/src/Library/JoomlaVersion/JoomlaVersion.php
+++ b/src/Library/JoomlaVersion/JoomlaVersion.php
@@ -85,7 +85,7 @@ class JoomlaVersion
 				'eolMajor'      => new DateTime('2012-09-27 18:00'),
 			],
 
-			// Joomla! 2 (1.6, 1.7, and 2.5 — because versioning was on crystal meth at the time…)
+			// Joomla! 2 (1.6, 1.7, and 2.5 - because versioning was on crystal meth at the time…)
 			'1.6'  => (object) [
 				'cycle'         => '2.5',
 				'firstRelease'  => new DateTime('2011-01-10 23:00'),

--- a/src/Model/Task.php
+++ b/src/Model/Task.php
@@ -315,7 +315,7 @@ class Task extends DataModel
 		{
 			$logger->info(
 				sprintf(
-					'System Task #%d — “%s”',
+					'System Task #%d - “%s”',
 					$pendingTask->id,
 					TaskUtils::getTaskDescription($pendingTask->type)
 				),
@@ -327,7 +327,7 @@ class Task extends DataModel
 		{
 			$logger->info(
 				sprintf(
-					'Site Task #%d — “%s” for site #%d (%s)',
+					'Site Task #%d - “%s” for site #%d (%s)',
 					$pendingTask->id,
 					TaskUtils::getTaskDescription($pendingTask->type),
 					$pendingTask->site_id,

--- a/src/Task/ExtensionUpdatesDirector.php
+++ b/src/Task/ExtensionUpdatesDirector.php
@@ -322,7 +322,7 @@ class ExtensionUpdatesDirector extends AbstractCallback
 			{
 				$this->logger->debug(
 					sprintf(
-						'No extension were queued for automatic updates or email on site #%d (%s) — all extensions were already queued up',
+						'No extension were queued for automatic updates or email on site #%d (%s) - all extensions were already queued up',
 						$site->id, $site->name
 					)
 				);

--- a/src/Task/ExtensionsUpdate.php
+++ b/src/Task/ExtensionsUpdate.php
@@ -60,7 +60,7 @@ class ExtensionsUpdate extends AbstractCallback
 			$this->reloadExtensionInformation($site);
 
 			/**
-			 * DO NOT REMOVE THIS CHECK — THIS IS A CONCURRENCY SANITY CHECK
+			 * DO NOT REMOVE THIS CHECK - THIS IS A CONCURRENCY SANITY CHECK
 			 *
 			 * It is possible that there were no items in the queue when we tried to pop an item. However, between then
 			 * and now we've done a fair amount of work which gives enough time for another process to enqueue a new

--- a/templates/system/fatal.html
+++ b/templates/system/fatal.html
@@ -81,7 +81,7 @@
 				The server returned the following error:
 			</p>
 			<p>
-				{{code}} — <span style="color: #c81d23; font-weight: bolder">{{message}}</span>
+				{{code}} - <span style="color: #c81d23; font-weight: bolder">{{message}}</span>
 			</p>
 		</div>
 	</div>


### PR DESCRIPTION
As discussed previously #58 in en-GB we use an en-dash with a space and not an em-dash without a space.

[source](https://accuracymatters.co.uk/how-to-use-the-em-dash-en-dash-and-hyphen/#:~:text=The%20preferred%20mark%20in%20UK,comma%2C%20a%20colon%20or%20parenthesis)

Seems I forgot to make the changes. Note I did not change the greek language files