### PR TITLE
scss fix

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -264,7 +264,7 @@
 				]
 			}
 		],
-		"sass": [
+		"scss": [
 			{
 				"folder": "media/scss",
 				"outdir": "media/css",


### PR DESCRIPTION
generate the css files correctly

before 
Code updated but still has issues :(


composer run-script scss 

```
> \Akeeba\Panopticon\Composer\InstallationScript::sass
'sass' is not recognized as an internal or external command,
operable program or batch file.
```

composer install
```
> \Akeeba\Panopticon\Composer\InstallationScript::copyNodeDependencies
> \Akeeba\Panopticon\Composer\InstallationScript::babel
> \Akeeba\Panopticon\Composer\InstallationScript::sass
'sass' is not recognized as an internal or external command,
operable program or batch file.
> \Akeeba\Panopticon\Composer\InstallationScript::copyPackageLock
> \Akeeba\Panopticon\Composer\InstallationScript::makeVersionPhp
> \Akeeba\Panopticon\Composer\InstallationScript::postComposerUpdate
> \Akeeba\Panopticon\Composer\InstallationScript::schemaUpdate
```