### PR TITLE
Search Input size

### DIFF
--- a/ViewTemplates/Backuptasks/default.blade.php
+++ b/ViewTemplates/Backuptasks/default.blade.php
@@ -30,7 +30,7 @@ $profileOptions = $this->getProfileOptions();
     <div class="my-2 border rounded-1 p-2 bg-body-tertiary">
         <div class="d-flex flex-row justify-content-center">
             <div class="input-group" style="max-width: max(50%, 25em)">
-                <input type="search" class="form-control" id="search"
+                <input type="search" class="form-control form-control-lg" id="search"
                        placeholder="@lang('PANOPTICON_LBL_FORM_SEARCH')"
                        name="name" value="{{{ $model->getState('name', '') }}}">
                 <label for="search" class="sr-only">@lang('PANOPTICON_LBL_FORM_SEARCH')</label>

--- a/ViewTemplates/Coreupdates/default.blade.php
+++ b/ViewTemplates/Coreupdates/default.blade.php
@@ -34,7 +34,7 @@ JS;
         <div class="d-flex flex-column flex-lg-row gap-2 gap-lg-3 justify-content-center align-items-center">
             {{-- Search --}}
             <div class="input-group" @if(empty($this->groupMap)) style="max-width: max(25em, 50%)" @endif>
-                <input type="search" class="form-control" id="search"
+                <input type="search" class="form-control form-control-lg" id="search"
                        placeholder="@lang('PANOPTICON_LBL_FORM_SEARCH')"
                        name="name" value="{{{ $model->getState('name', '') }}}">
                 <label for="search" class="sr-only">@lang('PANOPTICON_LBL_FORM_SEARCH')</label>

--- a/ViewTemplates/Extupdates/default.blade.php
+++ b/ViewTemplates/Extupdates/default.blade.php
@@ -66,7 +66,7 @@ JS;
         <div class="d-flex flex-column flex-lg-row gap-2 gap-lg-3 justify-content-center align-items-center">
             {{-- Search --}}
             <div class="input-group" @if(empty($this->groupMap)) style="max-width: max(25em, 50%)" @endif>
-                <input type="search" class="form-control" id="search"
+                <input type="search" class="form-control form-control-lg" id="search"
                        placeholder="@lang('PANOPTICON_LBL_FORM_SEARCH')"
                        name="search" value="{{{ $model->getState('search', '') }}}">
                 <label for="search" class="sr-only">@lang('PANOPTICON_LBL_FORM_SEARCH')</label>

--- a/ViewTemplates/Groups/default.blade.php
+++ b/ViewTemplates/Groups/default.blade.php
@@ -18,7 +18,7 @@ $token = $this->container->session->getCsrfToken()->getValue();
 <form action="@route('index.php?view=groups')" method="post" name="adminForm" id="adminForm">
     <div class="my-2 d-flex flex-row justify-content-center border rounded-1 p-2 bg-body-tertiary">
         <div class="input-group" style="max-width: max(50%, 25em)">
-            <input type="search" class="form-control" id="search"
+            <input type="search" class="form-control form-control-lg" id="search"
                    placeholder="@lang('PANOPTICON_LBL_FORM_SEARCH')"
                    name="title" value="{{{ $model->getState('title', '') }}}">
             <label for="search" class="sr-only">@lang('PANOPTICON_LBL_FORM_SEARCH')</label>

--- a/ViewTemplates/Logs/default.blade.php
+++ b/ViewTemplates/Logs/default.blade.php
@@ -97,7 +97,7 @@ $token = $this->container->session->getCsrfToken()->getValue();
     <div class="my-2 border rounded-1 p-2 bg-body-tertiary">
         <div class="my-2 d-flex flex-row justify-content-center p-2">
             <div class="input-group" style="max-width: max(50%, 25em)">
-                <input type="search" class="form-control" id="search"
+                <input type="search" class="form-control form-control-lg" id="search"
                        placeholder="@lang('PANOPTICON_LBL_FORM_SEARCH')"
                        name="search" value="{{{ $model->getState('search', '') }}}">
                 <label for="search" class="sr-only">@lang('PANOPTICON_LBL_FORM_SEARCH')</label>

--- a/ViewTemplates/Mailtemplates/default.blade.php
+++ b/ViewTemplates/Mailtemplates/default.blade.php
@@ -22,7 +22,7 @@ $langInfo = $this->getContainer()->helper->setup->getLanguagesAsFlagInfo(
 <form action="@route('index.php?view=mailtemplates')" method="post" name="adminForm" id="adminForm">
     <div class="my-2 d-flex flex-row justify-content-center border rounded-1 p-2 bg-body-tertiary">
         <div class="input-group" style="max-width: max(50%, 25em)">
-            <input type="search" class="form-control" id="search"
+            <input type="search" class="form-control form-control-lg" id="search"
                    placeholder="@lang('PANOPTICON_LBL_FORM_SEARCH')"
                    name="name" value="{{{ $model->getState('subject', '') }}}">
             <label for="search" class="sr-only">@lang('PANOPTICON_LBL_FORM_SEARCH')</label>

--- a/ViewTemplates/Main/default.blade.php
+++ b/ViewTemplates/Main/default.blade.php
@@ -55,7 +55,7 @@ JS;
         <div class="d-flex flex-column flex-lg-row gap-2 gap-lg-3 justify-content-center align-items-center">
             {{-- Search --}}
             <div class="input-group" @if(empty($this->groupMap)) style="max-width: max(25em, 50%)" @endif>
-                <input type="search" class="form-control" id="search"
+                <input type="search" class="form-control form-control-lg" id="search"
                        placeholder="@lang('PANOPTICON_LBL_FORM_SEARCH')"
                        name="search" value="{{{ $model->getState('search', '') }}}">
                 <label for="search" class="sr-only">@lang('PANOPTICON_LBL_FORM_SEARCH')</label>

--- a/ViewTemplates/Scannertasks/default.blade.php
+++ b/ViewTemplates/Scannertasks/default.blade.php
@@ -28,7 +28,7 @@ $i     = 1;
     <div class="my-2 border rounded-1 p-2 bg-body-tertiary">
         <div class="d-flex flex-row justify-content-center">
             <div class="input-group" style="max-width: max(50%, 25em)">
-                <input type="search" class="form-control" id="search"
+                <input type="search" class="form-control form-control-lg" id="search"
                        placeholder="@lang('PANOPTICON_LBL_FORM_SEARCH')"
                        name="name" value="{{{ $model->getState('name', '') }}}">
                 <label for="search" class="sr-only">@lang('PANOPTICON_LBL_FORM_SEARCH')</label>

--- a/ViewTemplates/Sites/default.blade.php
+++ b/ViewTemplates/Sites/default.blade.php
@@ -31,7 +31,7 @@ JS;
     <div class="my-2 d-flex flex-column flex-lg-row gap-2 gap-lg-3 justify-content-center border rounded-1 p-2 bg-body-tertiary">
         {{-- Search --}}
         <div class="input-group" @if(empty($this->groupMap)) style="max-width: max(25em, 50%)" @endif>
-            <input type="search" class="form-control" id="search"
+            <input type="search" class="form-control form-control-lg" id="search"
                    placeholder="@lang('PANOPTICON_LBL_FORM_SEARCH')"
                    name="name" value="{{{ $model->getState('name', '') }}}">
             <label for="search" class="sr-only">@lang('PANOPTICON_LBL_FORM_SEARCH')</label>

--- a/ViewTemplates/Sites/item_extensions.blade.php
+++ b/ViewTemplates/Sites/item_extensions.blade.php
@@ -201,7 +201,7 @@ $shouldCollapse = $extensionsQuickInfo->update == 0 && $extensionsQuickInfo->sit
                     <span class="fa fa-fw fa-search" aria-hidden="true"></span>
                 </span>
                     <input type="search" name="extensions-filter-search" id="extensions-filter-search"
-                           class="form-control"
+                           class="form-control form-control-lg"
                     >
                     <button type="button" class="btn btn-outline-secondary"
                             id="extensions-filter-search-button">

--- a/ViewTemplates/Sysconfig/default_extupdates.blade.php
+++ b/ViewTemplates/Sysconfig/default_extupdates.blade.php
@@ -67,7 +67,7 @@ $config = $this->container->appConfig;
                     <span class="fa fa-fw fa-search" aria-hidden="true"></span>
                 </span>
                 <input type="search" name="extensions-filter-search" id="extensions-filter-search"
-                       class="form-control"
+                       class="form-control form-control-lg"
                 >
                 <button type="button" class="btn btn-outline-secondary"
                         id="extensions-filter-search-button">

--- a/ViewTemplates/Tasks/default.blade.php
+++ b/ViewTemplates/Tasks/default.blade.php
@@ -26,7 +26,7 @@ $i     = 1;
     <div class="my-2 border rounded-1 p-2 bg-body-tertiary">
         <div class="d-flex flex-row justify-content-center">
             <div class="input-group" style="max-width: max(50%, 25em)">
-                <input type="search" class="form-control" id="search"
+                <input type="search" class="form-control form-control-lg" id="search"
                        placeholder="@lang('PANOPTICON_LBL_FORM_SEARCH')"
                        name="name" value="{{{ $model->getState('name', '') }}}">
                 <label for="search" class="sr-only">@lang('PANOPTICON_LBL_FORM_SEARCH')</label>

--- a/ViewTemplates/Users/default.blade.php
+++ b/ViewTemplates/Users/default.blade.php
@@ -23,7 +23,7 @@ $langInfo   = $this->getContainer()->helper->setup->getLanguagesAsFlagInfo(
 
     <div class="my-2 d-flex flex-row justify-content-center border rounded-1 p-2 bg-body-tertiary">
         <div class="input-group" style="max-width: max(50%, 25em)">
-            <input type="search" class="form-control" id="search"
+            <input type="search" class="form-control form-control-lg" id="search"
                    placeholder="@lang('PANOPTICON_LBL_FORM_SEARCH')"
                    name="search" value="{{{ $model->getState('search', '') }}}">
             <label for="search" class="sr-only">@lang('PANOPTICON_LBL_FORM_SEARCH')</label>


### PR DESCRIPTION
On pages where there is now both a search and a groups input you can see that they are of different sizes.

![image](https://github.com/akeeba/panopticon/assets/1296369/92990cbc-0462-481e-a6d2-049e720ac5da)

This PR adds the css class "form-control-lg" to the search input so that they are the same size

![image](https://github.com/akeeba/panopticon/assets/1296369/890f8f22-cc2b-422a-9acf-8182c716aa7e)

For consistency I have also changed the size of all search inputs even when there is no group input.

![image](https://github.com/akeeba/panopticon/assets/1296369/61cfbdcb-a8a2-4b4d-a658-dc0618da7f01)
