### PR TITLE
<hr> is self closing

### DIFF
--- a/ViewTemplates/Sites/item_joomlaupdate.blade.php
+++ b/ViewTemplates/Sites/item_joomlaupdate.blade.php
@@ -180,7 +180,7 @@ $jVersionHelper = new JoomlaVersion($this->getContainer())
                 </p>
                 {{-- Is there a new version available, which cannot be installed? --}}
                 @if (version_compare($config->get('core.latest.version'), $config->get('core.current.version'), 'lt'))
-                    <hr />
+                    <hr>
                     <p class="my-2 text-warning-emphasis fw-semibold">
                         @sprintf('PANOPTICON_SITE_LBL_JUPDATE_CANNOT_INSTALL', $this->escape($config->get('core.latest.version')))
                     </p>
@@ -211,7 +211,7 @@ $jVersionHelper = new JoomlaVersion($this->getContainer())
                 </p>
                 {{-- Is there a new version available, which cannot be installed? --}}
                 @if (version_compare($config->get('core.latest.version'), $config->get('core.current.version'), 'lt'))
-                    <hr />
+                    <hr>
                     <p class="my-2 text-warning-emphasis fw-semibold">
                         @sprintf('PANOPTICON_SITE_LBL_JUPDATE_CANNOT_INSTALL', $this->escape($config->get('core.latest.version')))
                     </p>
@@ -235,7 +235,7 @@ $jVersionHelper = new JoomlaVersion($this->getContainer())
                 </h4>
                 {{-- Is there a new version available, which cannot be installed? --}}
                 @if (version_compare($config->get('core.latest.version'), $config->get('core.current.version'), 'lt'))
-                    <hr />
+                    <hr>
                     <p class="my-2 text-warning-emphasis fw-semibold">
                         @sprintf('PANOPTICON_SITE_LBL_JUPDATE_CANNOT_INSTALL', $this->escape($config->get('core.latest.version')))
                     </p>
@@ -381,7 +381,7 @@ $jVersionHelper = new JoomlaVersion($this->getContainer())
         @endif
 
         @if (!$config->get('core.canUpgrade', false) && $config->get('core.extensionAvailable', true) && $config->get('core.updateSiteAvailable', true))
-            <hr class="mt-4" />
+            <hr class="mt-4">
 
             <details>
                 <summary class="text-info">

--- a/ViewTemplates/Sites/item_notes.blade.php
+++ b/ViewTemplates/Sites/item_notes.blade.php
@@ -33,7 +33,7 @@ defined('AKEEBA') || die;
         @else
             {{ $this->item->notes }}
         @endif
-        <hr/>
+        <hr>
         <a href="@route(sprintf('index.php?view=site&task=edit&id=%u', $this->item->getId()))#siteTabContentNotes">
             <span class="fa fa-fw fa-pencil" aria-hidden="true"></span>
             @lang('PANOPTICON_SITE_LBL_NOTES_EDIT')

--- a/ViewTemplates/Sites/item_php.blade.php
+++ b/ViewTemplates/Sites/item_php.blade.php
@@ -158,7 +158,7 @@ $hasError                = !empty($lastError);
                 @sprintf('PANOPTICON_SITE_LBL_PHP_SECURITY_ONLY', $this->getContainer()->html->basic->date($versionInfo?->dates?->eol?->format(DATE_RFC7231)))
             </p>
 
-            <hr/>
+            <hr>
             <p class="text-warning-emphasis">
                 @sprintf('PANOPTICON_SITE_LBL_PHP_SHOULD_UPGRADE', $this->escape($phpVersion->getRecommendedSupportedBranch()))
             </p>
@@ -182,7 +182,7 @@ $hasError                = !empty($lastError);
             </p>
 
             @if (!$isLatestBranch)
-                <hr/>
+                <hr>
                 <p class="text-warning-emphasis">
                     @sprintf('PANOPTICON_SITE_LBL_PHP_NEWER_BRANCH_AVAILABLE', $this->escape($phpVersion->getLatestBranch()), $this->getContainer()->html->basic->date($versionInfo?->dates?->activeSupport?->format(DATE_RFC7231)))
                 </p>

--- a/ViewTemplates/Sites/troubleshoot.blade.php
+++ b/ViewTemplates/Sites/troubleshoot.blade.php
@@ -356,7 +356,7 @@ $possibleJ3Endpoint = $maybeJ3NeedsIndex
 				?>
 
             @if ($hasRequestDebug || $hasExceptionDebug)
-                <hr class="my-3" />
+                <hr class="my-3">
                 <p class="fw-semibold">
                     @lang('PANOPTICON_SITES_LBL_TROUBLESHOOT_DEBUG_INFO')
                 </p>

--- a/src/Helper/DefaultTemplate.php
+++ b/src/Helper/DefaultTemplate.php
@@ -131,7 +131,7 @@ abstract class DefaultTemplate
 
 			if ($isDivider)
 			{
-				$html .= '<hr class="dropdown-divider" />';
+				$html .= '<hr class="dropdown-divider">';
 			}
 			elseif ($isDisabled)
 			{


### PR DESCRIPTION
The code base uses a mixture of

`<hr>` - valid html
`<hr />` - valid xhtml
`<hr/>` - not valid

As the pages are all html this PR corrects this inconsistency and makes sure they are all valid html ie `<hr>`

The same problem can be observed with the `<br>` and this is much more prevalent in the codebase and language files