### PR TITLE
Pre-check circle

### DIFF
--- a/ViewTemplates/Setup/precheck.php
+++ b/ViewTemplates/Setup/precheck.php
@@ -17,7 +17,7 @@ window.addEventListener('DOMContentLoaded', () => {
    if (div) {
        div.classList.remove('d-none');
    }
-   
+
    if (typeof bootstrap.Collapse !== 'function') {
        document.getElementById('brokenJavaScript').classList.remove('d-none');
    }
@@ -95,7 +95,7 @@ $this->getContainer()->application->getDocument()->addScriptDeclaration($js);
 
 	<div class="px-4 py-5 my-0 text-center d-none" id="systemsGo">
 		<div class="mx-auto mb-4">
-			<span class="badge bg-success rounded-5">
+			<span class="badge bg-success rounded-5 p-2">
 				<span class="far fa-check-circle display-5" aria-hidden="true"></span>
 			</span>
 		</div>


### PR DESCRIPTION
Badges in BS do not have even padding so when you use them for a circle they look odd unless you explicitly set even padding

### Before
![image](https://github.com/akeeba/panopticon/assets/1296369/e0f5b51c-c3d2-46f5-b71e-54b83cfe89eb)

### After
![image](https://github.com/akeeba/panopticon/assets/1296369/bea0a600-7fe8-47c6-857e-5a710b6ff5f2)
