### PR TITLE
External Link Icon

### DIFF
--- a/ViewTemplates/Coreupdates/default.blade.php
+++ b/ViewTemplates/Coreupdates/default.blade.php
@@ -220,7 +220,7 @@ JS;
                         <a href="{{{ $item->getBaseUrl() }}}" class="link-secondary text-decoration-none"
                            target="_blank">
                             {{{ $item->getBaseUrl() }}}
-                            <span class="fa fa-external-link-square" aria-hidden="true"></span>
+                            <span class="fa fa-external-link-alt fa-xs text-muted small" aria-hidden="true"></span>
                         </a>
                     </div>
                     {{-- Show group labels --}}

--- a/ViewTemplates/Coreupdates/default.blade.php
+++ b/ViewTemplates/Coreupdates/default.blade.php
@@ -220,7 +220,7 @@ JS;
                         <a href="{{{ $item->getBaseUrl() }}}" class="link-secondary text-decoration-none"
                            target="_blank">
                             {{{ $item->getBaseUrl() }}}
-                            <span class="fa fa-external-link-alt fa-xs text-muted small" aria-hidden="true"></span>
+                            <span class="fa fa-external-link-alt fa-xs text-muted" aria-hidden="true"></span>
                         </a>
                     </div>
                     {{-- Show group labels --}}

--- a/ViewTemplates/Extupdates/default.blade.php
+++ b/ViewTemplates/Extupdates/default.blade.php
@@ -272,7 +272,7 @@ JS;
                         <a href="{{{ $site->getBaseUrl() }}}" class="link-secondary text-decoration-none"
                            target="_blank">
                             {{{ $site->getBaseUrl() }}}
-                            <span class="fa fa-external-link-square" aria-hidden="true"></span>
+                            <span class="fa fa-external-link-alt fa-xs text-muted small" aria-hidden="true"></span>
                         </a>
                     </div>
                     {{-- Show group labels --}}

--- a/ViewTemplates/Extupdates/default.blade.php
+++ b/ViewTemplates/Extupdates/default.blade.php
@@ -272,7 +272,7 @@ JS;
                         <a href="{{{ $site->getBaseUrl() }}}" class="link-secondary text-decoration-none"
                            target="_blank">
                             {{{ $site->getBaseUrl() }}}
-                            <span class="fa fa-external-link-alt fa-xs text-muted small" aria-hidden="true"></span>
+                            <span class="fa fa-external-link-alt fa-xs text-muted" aria-hidden="true"></span>
                         </a>
                     </div>
                     {{-- Show group labels --}}

--- a/ViewTemplates/Main/dashboard.blade.php
+++ b/ViewTemplates/Main/dashboard.blade.php
@@ -221,7 +221,7 @@ defined('AKEEBA') || die;
                         <a href="@{{ site.url }}" target="_blank"
                            class="link-opacity-50 link-opacity-100-hover link-offset-2 link-underline-opacity-25 link-underline-opacity-100-hover">
                             @{{ site.url }}
-                            <span class="fa fa-fw fa-square-arrow-up-right" aria-hidden="true"></span>
+                            <span class="fa fa-external-link-alt fa-xs text-muted small" aria-hidden="true"></span>
                         </a>
                     </div>
                 </div>

--- a/ViewTemplates/Main/dashboard.blade.php
+++ b/ViewTemplates/Main/dashboard.blade.php
@@ -221,7 +221,7 @@ defined('AKEEBA') || die;
                         <a href="@{{ site.url }}" target="_blank"
                            class="link-opacity-50 link-opacity-100-hover link-offset-2 link-underline-opacity-25 link-underline-opacity-100-hover">
                             @{{ site.url }}
-                            <span class="fa fa-external-link-alt fa-xs text-muted small" aria-hidden="true"></span>
+                            <span class="fa fa-external-link-alt fa-xs text-muted" aria-hidden="true"></span>
                         </a>
                     </div>
                 </div>

--- a/ViewTemplates/Main/default.blade.php
+++ b/ViewTemplates/Main/default.blade.php
@@ -99,7 +99,7 @@ $mainModel = $this->getModel('main');
                                 <span class="visually-hidden">@lang('PANOPTICON_MAIN_SITES_LBL_URL_SCREENREADER')</span>
                                 <a href="{{{ $url }}}" class="link-secondary text-decoration-none" target="_blank">
                                     {{{ $url }}}
-                                    <span class="fa fa-external-link-alt fa-xs text-muted small" aria-hidden="true"></span>
+                                    <span class="fa fa-external-link-alt fa-xs text-muted" aria-hidden="true"></span>
                                 </a>
                             </div>
                             {{-- Show group labels --}}

--- a/ViewTemplates/Main/default.blade.php
+++ b/ViewTemplates/Main/default.blade.php
@@ -99,7 +99,7 @@ $mainModel = $this->getModel('main');
                                 <span class="visually-hidden">@lang('PANOPTICON_MAIN_SITES_LBL_URL_SCREENREADER')</span>
                                 <a href="{{{ $url }}}" class="link-secondary text-decoration-none" target="_blank">
                                     {{{ $url }}}
-                                    <span class="fa fa-external-link-square" aria-hidden="true"></span>
+                                    <span class="fa fa-external-link-alt fa-xs text-muted small" aria-hidden="true"></span>
                                 </a>
                             </div>
                             {{-- Show group labels --}}

--- a/ViewTemplates/Sites/doctor.blade.php
+++ b/ViewTemplates/Sites/doctor.blade.php
@@ -53,13 +53,13 @@ $hasAkeebaBackupError = $this->akeebaBackupConnectionError instanceof Throwable
             <span class="fa fa-users fa-fw text-secondary me-1" aria-hidden="true"></span>
             <span class="{{ ($baseUri->getScheme() === 'https') ? 'text-muted' : 'text-danger' }}">{{{ $baseUri->getScheme() }}}://</span><span
                     class="fw-medium">{{{ $baseUri->toString(['user', 'pass', 'host', 'port', 'path', 'query', 'fragment']) }}}</span>
-            <span class="fa fa-external-link-alt fa-xs text-muted small" aria-hidden="true"></span>
+            <span class="fa fa-external-link-alt fa-xs text-muted" aria-hidden="true"></span>
         </a>
         <a href="{{{ $this->item->getAdminUrl() }}}" target="_blank" class="text-decoration-none">
             <span class="fa fa-user-secret fa-fw text-secondary me-1" aria-hidden="true"></span>
             <span class="{{ ($adminUri->getScheme() === 'https') ? 'text-muted' : 'text-danger' }}">{{{ $adminUri->getScheme() }}}://</span><span
                     class="fw-medium">{{{ $adminUri->toString(['user', 'pass', 'host', 'port', 'path']) }}}</span>@if(!empty($adminUri->getQuery()))<span class="text-body-tertiary">{{{ $adminUri->toString(['query', 'fragment']) }}}</span>@endif
-            <span class="fa fa-external-link-alt fa-xs text-muted small" aria-hidden="true"></span>
+            <span class="fa fa-external-link-alt fa-xs text-muted" aria-hidden="true"></span>
         </a>
     </div>
 </div>

--- a/ViewTemplates/Sites/item.blade.php
+++ b/ViewTemplates/Sites/item.blade.php
@@ -51,13 +51,13 @@ $favIcon = $this->item->getFavicon(asDataUrl: true, onlyIfCached: true);
             <span class="fa fa-users fa-fw text-secondary me-1" aria-hidden="true"></span>
             <span class="{{ ($this->baseUri->getScheme() === 'https') ? 'text-muted' : 'text-danger' }}">{{{ $this->baseUri->getScheme() }}}://</span><span
                     class="fw-medium">{{{ $this->baseUri->toString(['user', 'pass', 'host', 'port', 'path', 'query', 'fragment']) }}}</span>
-            <span class="fa fa-external-link-alt fa-xs text-muted small" aria-hidden="true"></span>
+            <span class="fa fa-external-link-alt fa-xs text-muted" aria-hidden="true"></span>
         </a>
         <a href="{{{ $this->item->getAdminUrl() }}}" target="_blank" class="text-decoration-none">
             <span class="fa fa-user-secret fa-fw text-secondary me-1" aria-hidden="true"></span>
             <span class="{{ ($this->adminUri->getScheme() === 'https') ? 'text-muted' : 'text-danger' }}">{{{ $this->adminUri->getScheme() }}}://</span><span
                     class="fw-medium">{{{ $this->adminUri->toString(['user', 'pass', 'host', 'port', 'path']) }}}</span>@if(!empty($this->adminUri->getQuery()))<span class="text-body-tertiary">{{{ $this->adminUri->toString(['query', 'fragment']) }}}</span>@endif
-            <span class="fa fa-external-link-alt fa-xs text-muted small" aria-hidden="true"></span>
+            <span class="fa fa-external-link-alt fa-xs text-muted" aria-hidden="true"></span>
         </a>
     </div>
 </div>


### PR DESCRIPTION
There were three different types and styles of icons used to indicate an external link. This PR chooses just one but I guess its personal preference. Also removes a class `small` which does nothing when there is also `fa-xs`