### PR TITLE
backup_blade align icons

### DIFF
--- a/ViewTemplates/Sites/item_backup.blade.php
+++ b/ViewTemplates/Sites/item_backup.blade.php
@@ -372,10 +372,10 @@ $lastRefreshResponse = $this->siteConfig->get('akeebabackup.lastRefreshResponse'
                         {{-- Description, backup date, duration and size --}}
                         <td>
                             {{-- Row: origin and description --}}
-                            <div class="d-flex flex-column flex-lg-row gap-2">
+                            <div class="d-flex flex-column flex-lg-row gap-1">
                                 {{-- Origin --}}
                                 <div>
-                                <span class="{{ $originIcon }} me" aria-hidden="true"
+                                <span class="{{ $originIcon }} fa-fw" aria-hidden="true"
                                       data-bs-toggle="tooltip" data-bs-placement="bottom"
                                       data-bs-title="@lang('PANOPTICON_SITES_LBL_AKEEBABACKUP_ORIGIN'): {{{ $originDescription }}}"
                                 ></span>
@@ -413,10 +413,10 @@ $lastRefreshResponse = $this->siteConfig->get('akeebabackup.lastRefreshResponse'
                             <div class="row mt-1">
                                 {{-- Start Date --}}
                                 <div class="col-lg-5">
-                                    <span class="fa fa-calendar" aria-hidden="true"
+                                    <span class="fa fa-calendar fa-fw" aria-hidden="true"
                                           data-bs-toggle="tooltip" data-bs-placement="bottom"
                                           data-bs-title="@lang('PANOPTICON_SITES_LBL_AKEEBABACKUP_START')"
-                                    ></span>&nbsp;
+                                    ></span>
                                     <span class="visually-hidden">@lang('PANOPTICON_SITES_LBL_AKEEBABACKUP_START')</span>
 										<?= $startTime ?> <?= $timeZoneText ?>
                                 </div>
@@ -451,7 +451,7 @@ $lastRefreshResponse = $this->siteConfig->get('akeebabackup.lastRefreshResponse'
                             {{-- Backup Profile (condensed display) --}}
                             <div class="row mt-1">
                                 <div class="col-md">
-                                <span class="fa fa-users" aria-hidden="true"
+                                <span class="fa fa-users fa-fw" aria-hidden="true"
                                       data-bs-toggle="tooltip" data-bs-placement="bottom"
                                       data-bs-title="@lang('PANOPTICON_SITES_LBL_AKEEBABACKUP_PROFILE')"
                                 ></span>


### PR DESCRIPTION
Removes some hard coded spaces and `me-*` classes and a non existent  `me` class Applies the `fa-fw` class to the first icons in the row so that the text will align correctly

### Before
![image](https://github.com/akeeba/panopticon/assets/1296369/8034dd78-9878-4d1f-a5ef-21ebf92dade8)

### After
![image](https://github.com/akeeba/panopticon/assets/1296369/e9d36718-cdb8-4ae3-ad10-637bd57c92b2)
