### PR TITLE
View Logs text alignment

### DIFF
--- a/ViewTemplates/Logs/default.blade.php
+++ b/ViewTemplates/Logs/default.blade.php
@@ -172,7 +172,7 @@ $token = $this->container->session->getCsrfToken()->getValue();
                         <div class="flex-grow-1">
                             @yieldRepeatable('logFileName', $logName)
                         </div>
-                        <div class="small font-monospace text-success-emphasis">
+                        <div class="font-monospace">
                             {{ $this->filesize($logName) }}
                         </div>
                     </div>


### PR DESCRIPTION
Because of the class small the text for the file size is not aligned with the rest of the text.

Also removes a class that has no effect

### Before
![image](https://github.com/akeeba/panopticon/assets/1296369/739ec03d-2c8c-4725-aaa4-c0b329cefa60)

### After
![image](https://github.com/akeeba/panopticon/assets/1296369/b7f8c740-c4ac-48b7-8a8f-e95cf8be662e)


ps I want to get rid of all the inline css - are you ok with me creating a few extra utility classes (eg w-1, w-5, w-10)