### PR TITLE
invalid colspan

### DIFF
--- a/ViewTemplates/Setup/precheck.php
+++ b/ViewTemplates/Setup/precheck.php
@@ -176,7 +176,7 @@ $this->getContainer()->application->getDocument()->addScriptDeclaration($js);
 						<tbody>
 						<?php foreach($this->reqSettings as $option): ?>
 							<tr>
-								<th colspan="row">
+								<th>
 									<?= $this->escape($option['label']) ?>
 									<?php if ($option['notice'] ?? ''): ?>
 										<div class="small text-muted">
@@ -217,7 +217,7 @@ $this->getContainer()->application->getDocument()->addScriptDeclaration($js);
 						<tbody>
 						<?php foreach($this->recommendedSettings as $option): ?>
 							<tr>
-								<th colspan="row">
+								<th>
 									<?= $this->escape($option['label']) ?>
 									<?php if ($option['notice'] ?? ''): ?>
 										<div class="small text-muted">


### PR DESCRIPTION
There is no such thing as colspan=row - this does nothing

I suspect you might have meant scope = row but for now I am just removing it completely and will look at all table accessibility another time.