### PR TITLE
contributors

### DIFF
--- a/ViewTemplates/About/default_contributors.blade.php
+++ b/ViewTemplates/About/default_contributors.blade.php
@@ -16,26 +16,31 @@ defined('AKEEBA') || die;
 <p class="small text-muted">@lang('PANOPTICON_ABOUT_LBL_CONTRIBUTORS_INFO')</p>
 
 @if (!empty($this->contributors))
-<div class="d-flex flex-row align-items-stretch justify-content-evenly my-4">
+<div class="row row-cols-2 row-cols-md-5 g-4">
     @foreach($this->contributors as $contributor)
-    <div class="card text-center" style="max-width: min(33%, 12rem)">
-        <img src="{{{ $contributor->avatar_url }}}" class="card-img-top" alt="@sprintf('PANOPTICON_ABOUT_LBL_AVATAR_FOR', $this->escape($contributor->login))">
-        <div class="card-body">
-            <h5 class="card-title text-info">
-                {{{ $contributor->login }}}
-            </h5>
-            <p class="card-text">
-                @sprintf('PANOPTICON_ABOUT_LBL_CONTRIBUTIONS', $contributor->contributions)
-            </p>
-            <a href="{{{ $contributor->html_url }}}" class="btn btn-outline-info" target="_blank">
-                <span class="fab fa-fw fa-github" aria-hidden="true"></span>
-                <span aria-hidden="true">
-                    @lang('PANOPTICON_ABOUT_LBL_GITHUB_PROFILE')
-                </span>
-                <span class="visually-hidden">
-                    @sprintf('PANOPTICON_ABOUT_LBL_GITHUB_PROFILE_FOR', $this->escape($contributor->login))
-                </span>
-            </a>
+    <div class="col">
+        <div class="card h-100 text-center">
+            <img src="{{{ $contributor->avatar_url }}}" class="card-img-top"
+                alt="@sprintf('PANOPTICON_ABOUT_LBL_AVATAR_FOR', $this->escape($contributor->login))">
+            <div class="card-body">
+                <h5 class="card-title text-info">
+                    {{{ $contributor->login }}}
+                </h5>
+                <p class="card-text">
+                    @sprintf('PANOPTICON_ABOUT_LBL_CONTRIBUTIONS', $contributor->contributions)
+                </p>
+            </div>
+            <div class="card-footer bg-transparent border-top-0">
+                <a href="{{{ $contributor->html_url }}}" class="btn btn-outline-info" target="_blank">
+                    <span class="fab fa-fw fa-github" aria-hidden="true"></span>
+                    <span aria-hidden="true">
+                        @lang('PANOPTICON_ABOUT_LBL_GITHUB_PROFILE')
+                    </span>
+                    <span class="visually-hidden">
+                        @sprintf('PANOPTICON_ABOUT_LBL_GITHUB_PROFILE_FOR', $this->escape($contributor->login))
+                    </span>
+                </a>
+            </div>
         </div>
     </div>
     @endforeach


### PR DESCRIPTION
While removing the inline style it became obvious it was better to rewrite the markup as it would not adjust for more contributors and if someone has a very long name that makes it wrap then everything will still line up nicely . I_t also wasnt responsive but I guess thats not as important here_

### Before
![image](https://github.com/akeeba/panopticon/assets/1296369/7dd9a277-dbe3-4422-98f4-35277120d35f)

### After
![image](https://github.com/akeeba/panopticon/assets/1296369/b2e4481b-6460-4b6b-a559-9b3c27032c49)
