### PR TITLE
mail template urls

### DIFF
--- a/ViewTemplates/Mailtemplates/form.blade.php
+++ b/ViewTemplates/Mailtemplates/form.blade.php
@@ -74,7 +74,7 @@ $item = $this->getModel();
 	            $item->html,
 	            [
 					'id' => 'html',
-					'relative_urls' => true,
+					'relative_urls' => false,
 					'content_style' => $this->css
                 ]
             ) }}


### PR DESCRIPTION
links in an email must be absolute and not relative but the setting for tinymce was relative_urls->true

when it is set to false (as this PR does) then if you create a link with a full url eg https://othersite.com/test.html it is maintained as a full url. If you just enter the link eg potato.html then it will be saved as https://thissite.com/potatol.html