### PR TITLE
RFC Column Link Title

### DIFF
--- a/ViewTemplates/Main/default.blade.php
+++ b/ViewTemplates/Main/default.blade.php
@@ -73,21 +73,21 @@ $mainModel = $this->getModel('main');
                 </span>
             </th>
             <th class="d-none d-md-table-cell" style="min-width: 2em">
-                {{ $this->getContainer()->html->grid->sort('PANOPTICON_LBL_TABLE_HEAD_NUM', 'id', $this->lists->order_Dir, $this->lists->order, 'browse') }}
+                {{ $this->getContainer()->html->grid->sort('PANOPTICON_LBL_TABLE_HEAD_NUM', 'id', $this->lists->order_Dir, $this->lists->order, 'browse', 'asc','PANOPTICON_LBL_TABLE_HEAD_NUM_SR') }}
             </th>
         </tr>
         </thead>
         <tbody class="table-group-divider">
-		<?php
-		/** @var \Akeeba\Panopticon\Model\Site $item */
-		?>
+        <?php
+        /** @var \Akeeba\Panopticon\Model\Site $item */
+        ?>
         @foreach($this->items as $item)
-				<?php
-				$url               = $item->getBaseUrl();
-				$config            = $item->getConfig();
-				$favicon           = $item->getFavicon(asDataUrl: true, onlyIfCached: true);
-				$certificateStatus = $item->getSSLValidityStatus();
-				?>
+                <?php
+                $url               = $item->getBaseUrl();
+                $config            = $item->getConfig();
+                $favicon           = $item->getFavicon(asDataUrl: true, onlyIfCached: true);
+                $certificateStatus = $item->getSSLValidityStatus();
+                ?>
             <tr>
                 <td>
                     <div class="d-flex flex-row gap-2">


### PR DESCRIPTION
As discussed before. The way I see this there are two options.

### Option 1
_as shown here_

The helper already supports a second string which is used for the title. That's not perfect for a screenreader as it sees it as a description which will only be announced in verbose mode. But its better than the hash and also means you get a title tooltip with some meaning

### Option 2
This would be my preferred option and the one which matches your original concept of having a separate string for both sets of users. Simply add an extra param upstream to the awf helper which will produce an aria-label on the link. This would be the _best_ for accessibility