### PR TITLE
sr-only visually-hidden

### DIFF
--- a/ViewTemplates/Backuptasks/default.blade.php
+++ b/ViewTemplates/Backuptasks/default.blade.php
@@ -33,7 +33,7 @@ $profileOptions = $this->getProfileOptions();
                 <input type="search" class="form-control form-control-lg" id="search"
                        placeholder="@lang('PANOPTICON_LBL_FORM_SEARCH')"
                        name="name" value="{{{ $model->getState('name', '') }}}">
-                <label for="search" class="sr-only">@lang('PANOPTICON_LBL_FORM_SEARCH')</label>
+                <label for="search" class="visually-hidden">@lang('PANOPTICON_LBL_FORM_SEARCH')</label>
                 <button type="submit"
                         class="btn btn-primary">
                     <span class="fa fa-search" aria-hidden="true"></span>

--- a/ViewTemplates/Coreupdates/default.blade.php
+++ b/ViewTemplates/Coreupdates/default.blade.php
@@ -37,7 +37,7 @@ JS;
                 <input type="search" class="form-control form-control-lg" id="search"
                        placeholder="@lang('PANOPTICON_LBL_FORM_SEARCH')"
                        name="name" value="{{{ $model->getState('name', '') }}}">
-                <label for="search" class="sr-only">@lang('PANOPTICON_LBL_FORM_SEARCH')</label>
+                <label for="search" class="visually-hidden">@lang('PANOPTICON_LBL_FORM_SEARCH')</label>
                 <button type="submit"
                         class="btn btn-primary">
                     <span class="fa fa-search" aria-hidden="true"></span>

--- a/ViewTemplates/Extupdates/default.blade.php
+++ b/ViewTemplates/Extupdates/default.blade.php
@@ -69,7 +69,7 @@ JS;
                 <input type="search" class="form-control form-control-lg" id="search"
                        placeholder="@lang('PANOPTICON_LBL_FORM_SEARCH')"
                        name="search" value="{{{ $model->getState('search', '') }}}">
-                <label for="search" class="sr-only">@lang('PANOPTICON_LBL_FORM_SEARCH')</label>
+                <label for="search" class="visually-hidden">@lang('PANOPTICON_LBL_FORM_SEARCH')</label>
                 <button type="submit"
                         class="btn btn-primary">
                     <span class="fa fa-search" aria-hidden="true"></span>

--- a/ViewTemplates/Groups/default.blade.php
+++ b/ViewTemplates/Groups/default.blade.php
@@ -21,7 +21,7 @@ $token = $this->container->session->getCsrfToken()->getValue();
             <input type="search" class="form-control form-control-lg" id="search"
                    placeholder="@lang('PANOPTICON_LBL_FORM_SEARCH')"
                    name="title" value="{{{ $model->getState('title', '') }}}">
-            <label for="search" class="sr-only">@lang('PANOPTICON_LBL_FORM_SEARCH')</label>
+            <label for="search" class="visually-hidden">@lang('PANOPTICON_LBL_FORM_SEARCH')</label>
             <button type="submit"
                     class="btn btn-primary">
                 <span class="fa fa-search" aria-hidden="true"></span>

--- a/ViewTemplates/Logs/default.blade.php
+++ b/ViewTemplates/Logs/default.blade.php
@@ -100,7 +100,7 @@ $token = $this->container->session->getCsrfToken()->getValue();
                 <input type="search" class="form-control form-control-lg" id="search"
                        placeholder="@lang('PANOPTICON_LBL_FORM_SEARCH')"
                        name="search" value="{{{ $model->getState('search', '') }}}">
-                <label for="search" class="sr-only">@lang('PANOPTICON_LBL_FORM_SEARCH')</label>
+                <label for="search" class="visually-hidden">@lang('PANOPTICON_LBL_FORM_SEARCH')</label>
                 <button type="submit"
                         class="btn btn-primary">
                     <span class="fa fa-search" aria-hidden="true"></span>

--- a/ViewTemplates/Mailtemplates/default.blade.php
+++ b/ViewTemplates/Mailtemplates/default.blade.php
@@ -25,7 +25,7 @@ $langInfo = $this->getContainer()->helper->setup->getLanguagesAsFlagInfo(
             <input type="search" class="form-control form-control-lg" id="search"
                    placeholder="@lang('PANOPTICON_LBL_FORM_SEARCH')"
                    name="name" value="{{{ $model->getState('subject', '') }}}">
-            <label for="search" class="sr-only">@lang('PANOPTICON_LBL_FORM_SEARCH')</label>
+            <label for="search" class="visually-hidden">@lang('PANOPTICON_LBL_FORM_SEARCH')</label>
             <button type="submit"
                     class="btn btn-primary">
                 <span class="fa fa-search" aria-hidden="true"></span>

--- a/ViewTemplates/Main/default.blade.php
+++ b/ViewTemplates/Main/default.blade.php
@@ -212,7 +212,7 @@ $mainModel = $this->getModel('main');
                     <input type="search" class="form-control form-control-lg" id="search"
                            placeholder="@lang('PANOPTICON_LBL_FORM_SEARCH')"
                            name="search" value="{{{ $model->getState('search', '') }}}">
-                    <label for="search" class="sr-only">@lang('PANOPTICON_LBL_FORM_SEARCH')</label>
+                    <label for="search" class="visually-hidden">@lang('PANOPTICON_LBL_FORM_SEARCH')</label>
                     <button type="submit"
                             class="btn btn-primary">
                         <span class="fa fa-search" aria-hidden="true"></span>

--- a/ViewTemplates/Scannertasks/default.blade.php
+++ b/ViewTemplates/Scannertasks/default.blade.php
@@ -31,7 +31,7 @@ $i     = 1;
                 <input type="search" class="form-control form-control-lg" id="search"
                        placeholder="@lang('PANOPTICON_LBL_FORM_SEARCH')"
                        name="name" value="{{{ $model->getState('name', '') }}}">
-                <label for="search" class="sr-only">@lang('PANOPTICON_LBL_FORM_SEARCH')</label>
+                <label for="search" class="visually-hidden">@lang('PANOPTICON_LBL_FORM_SEARCH')</label>
                 <button type="submit"
                         class="btn btn-primary">
                     <span class="fa fa-search" aria-hidden="true"></span>

--- a/ViewTemplates/Sites/default.blade.php
+++ b/ViewTemplates/Sites/default.blade.php
@@ -23,7 +23,7 @@ $token = $this->container->session->getCsrfToken()->getValue();
             <input type="search" class="form-control form-control-lg" id="search"
                    placeholder="@lang('PANOPTICON_LBL_FORM_SEARCH')"
                    name="name" value="{{{ $model->getState('name', '') }}}">
-            <label for="search" class="sr-only">@lang('PANOPTICON_LBL_FORM_SEARCH')</label>
+            <label for="search" class="visually-hidden">@lang('PANOPTICON_LBL_FORM_SEARCH')</label>
             <button type="submit"
                     class="btn btn-primary">
                 <span class="fa fa-search" aria-hidden="true"></span>

--- a/ViewTemplates/Tasks/default.blade.php
+++ b/ViewTemplates/Tasks/default.blade.php
@@ -29,7 +29,7 @@ $i     = 1;
                 <input type="search" class="form-control form-control-lg" id="search"
                        placeholder="@lang('PANOPTICON_LBL_FORM_SEARCH')"
                        name="name" value="{{{ $model->getState('name', '') }}}">
-                <label for="search" class="sr-only">@lang('PANOPTICON_LBL_FORM_SEARCH')</label>
+                <label for="search" class="visually-hidden">@lang('PANOPTICON_LBL_FORM_SEARCH')</label>
                 <button type="submit"
                         class="btn btn-primary">
                     <span class="fa fa-search" aria-hidden="true"></span>

--- a/ViewTemplates/Updatesummarytasks/default.blade.php
+++ b/ViewTemplates/Updatesummarytasks/default.blade.php
@@ -33,7 +33,7 @@ $i     = 1;
                 <input type="search" class="form-control form-control-lg" id="search"
                        placeholder="@lang('PANOPTICON_LBL_FORM_SEARCH')"
                        name="name" value="{{{ $model->getState('name', '') }}}">
-                <label for="search" class="sr-only">@lang('PANOPTICON_LBL_FORM_SEARCH')</label>
+                <label for="search" class="visually-hidden">@lang('PANOPTICON_LBL_FORM_SEARCH')</label>
                 <button type="submit"
                         class="btn btn-primary">
                     <span class="fa fa-search" aria-hidden="true"></span>

--- a/ViewTemplates/Users/default.blade.php
+++ b/ViewTemplates/Users/default.blade.php
@@ -26,7 +26,7 @@ $langInfo   = $this->getContainer()->helper->setup->getLanguagesAsFlagInfo(
             <input type="search" class="form-control form-control-lg" id="search"
                    placeholder="@lang('PANOPTICON_LBL_FORM_SEARCH')"
                    name="search" value="{{{ $model->getState('search', '') }}}">
-            <label for="search" class="sr-only">@lang('PANOPTICON_LBL_FORM_SEARCH')</label>
+            <label for="search" class="visually-hidden">@lang('PANOPTICON_LBL_FORM_SEARCH')</label>
             <button type="submit"
                     class="btn btn-primary">
                 <span class="fa fa-search" aria-hidden="true"></span>


### PR DESCRIPTION
sr-only class doesnt exist in bootstrap 5. it is only working here because it is also present in fontawesome

this PR changes the class to only use visually-hidden. better for long term maintainability to use the same class