### PR TITLE
lint scss

### DIFF
--- a/media/scss/section/_logo.scss
+++ b/media/scss/section/_logo.scss
@@ -10,7 +10,7 @@ svg.panopticonLogoColour {
 
 html[data-bs-theme=dark] svg.panopticonLogoColour {
   path.main {
-    fill: $gray-100
+    fill: $gray-100;
   }
 
   path.w {
@@ -22,25 +22,25 @@ svg.panopticonLogoColour
 {
   &[data-bs-theme=success] {
     path.w {
-      fill: $success
+      fill: $success;
     }
   }
 
   &[data-bs-theme=warning] {
     path.w {
-      fill: $warning
+      fill: $warning;
     }
   }
 
   &[data-bs-theme=danger] {
     path.w {
-      fill: $danger
+      fill: $danger;
     }
   }
 
   &[data-bs-theme=off] {
     path.w {
-      fill: $secondary
+      fill: $secondary;
     }
   }
 }


### PR DESCRIPTION
My linter keeps complaining to me about this LOW priority issue CSS allows you to omit the semicolon if the statement is the last statement in the rule set. However, this introduces inconsistency and requires anyone adding a property after that property to remember to append a semicolon.