### PR TITLE
navbar forced dark-mode?

### DIFF
--- a/templates/default/index.php
+++ b/templates/default/index.php
@@ -155,13 +155,13 @@ $importMap     = TemplateHelper::getImportMapAsJson();
 
 <?php // Toolbar / page title ?>
 <?php if (!empty($this->getToolbar()->getTitle()) || count($this->getToolbar()->getButtons())): ?>
-	<section class="navbar container-xl bg-secondary py-3 px-2 d-print-none" id="toolbar" data-bs-theme="dark"
+	<section class="navbar container-xl bg-secondary py-3 px-2 d-print-none" id="toolbar"
 	         aria-label="<?= $text->text('PANOPTICON_APP_LBL_TOOLBAR') ?>">
 		<div class="ms-2 me-auto d-flex flex-row gap-2">
 			<?= TemplateHelper::getRenderedToolbarButtons() ?>
 		</div>
 		 <?php if (!empty($this->getToolbar()->getTitle())): ?>
-			<h2 class="navbar-text ps-2 fs-5 py-0 my-0 me-2">
+			<h2 class="navbar-text text-light ps-2 fs-5 py-0 my-0 me-2">
 				<?= $this->getToolbar()->getTitle() ?>
 			</h2>
 		<?php endif; ?>


### PR DESCRIPTION
I couldn't understand why the dropdown menu for automations always had a dark background. It's because it has a hardcoded `data-bs-theme=dark`

For me it is confusing, and a misuse of that attribute to use it this way.

This PR removes the data-bs-theme and adjusts the class of the title. The automations dropdown is now styled the same as the other dropdown menus.

### Before Dark Mode
![image](https://github.com/akeeba/panopticon/assets/1296369/b6c51a6e-de87-47cd-86be-71168ce34df0)

### After Dark Mode
![image](https://github.com/akeeba/panopticon/assets/1296369/84172bb0-e070-4029-adb2-bac54f838920)

### Before Light Mode
![image](https://github.com/akeeba/panopticon/assets/1296369/1acc4e52-d531-4483-ad47-4163c0b6fe6d)

### After Light Mode
![image](https://github.com/akeeba/panopticon/assets/1296369/9f3ca2e1-1637-4189-94bd-c596a419ee76)

(there may be other _misuses_ of data-bs-theme)