### PR TITLE
Remove justify

### DIFF
--- a/ViewTemplates/Sites/item_php.blade.php
+++ b/ViewTemplates/Sites/item_php.blade.php
@@ -81,7 +81,7 @@ $hasError                = !empty(trim($this->siteConfig->get('core.lastErrorMes
                     <span class="fa fa-info-circle" aria-hidden="true"></span>
                     @lang('PANOPTICON_SITE_LBL_PHP_LTS_HEAD')
                 </summary>
-                <div class="mt-2 ps-3 pe-2 text-info" style="text-align: justify">
+                <div class="mt-2 ps-3 pe-2 text-info">
                     <p>
                         @lang('PANOPTICON_SITE_LBL_PHP_LTS_P1')
                     </p>


### PR DESCRIPTION
Agree with bootstrap. Especially as this was the only piece of text that was justfied.


> Note that we don’t provide utility classes for justified text. While, aesthetically, justified text might look more appealing, it does make word-spacing more random and therefore harder to read.


### before
![image](https://github.com/akeeba/panopticon/assets/1296369/eac2112c-d25d-439b-8eea-01ef158500e4)

### after
![image](https://github.com/akeeba/panopticon/assets/1296369/4dd4e1f5-b61b-4f5e-8320-a0166c938f74)
