### PR TITLE
Missing lang string

### DIFF
--- a/languages/en-GB.ini
+++ b/languages/en-GB.ini
@@ -1568,6 +1568,7 @@ PANOPTICON_MFA_TOTP_LBL_DISPLAYEDAS="Authenticator code (TOTP)"
 PANOPTICON_MFA_TOTP_LBL_SHORTINFO="Six-digit code which changes every 30 seconds."
 PANOPTICON_MFA_TOTP_LBL_CODE="Code"
 PANOPTICON_MFA_TOTP_LBL_PLACEHOLDER="Enter your six-digit code"
+PANOPTICON_MFA_LBL_HELP="Help on the wiki"
 
 [Overrides]
 PANOPTICON_OVERRIDES_TITLE="Template Overrides"


### PR DESCRIPTION
![image](https://github.com/akeeba/panopticon/assets/1296369/83169e56-6ffa-486f-83d9-cf06d7e1478a)

Not sure if the string is exactly what you intended