### PR TITLE
badge warning contrast

### DIFF
--- a/ViewTemplates/Main/dashboard.blade.php
+++ b/ViewTemplates/Main/dashboard.blade.php
@@ -219,7 +219,7 @@ defined('AKEEBA') || die;
                                     @lang('PANOPTICON_OVERRIDES_TITLE')
                                 </dt>
                                 <dd v-if="(site.overrides > 0)">
-                                    <span class="badge bg-warning"
+                                    <span class="badge text-bg-warning"
                                           v-bs:tooltip="akeeba.System.Text.plural('PANOPTICON_SITE_LBL_TEMPLATE_OVERRIDES_CHANGED_N', site.overrides)"
                                     >
                                         <span class="fa fa-fw fa-arrows-to-circle" aria-hidden="true"></span>
@@ -276,7 +276,7 @@ defined('AKEEBA') || die;
                                         <span v-if="(site.cms ?? 'joomla') === 'wordpress'">@lang('PANOPTICON_MAIN_DASH_LBL_EXTENSIONS_WP_UPDATE_ERROR')</span>
                                     </span>
 
-                                    <span class="badge bg-warning"
+                                    <span class="badge text-bg-warning"
                                           v-bs:tooltip="akeeba.System.Text.plural('PANOPTICON_MAIN_SITES_LBL_EXT_UPGRADE_N', site.extensions)"
                                     >
                                         <span class="fa fa-fw fa-box-open" aria-hidden="true"></span>

--- a/ViewTemplates/Main/site_joomla.blade.php
+++ b/ViewTemplates/Main/site_joomla.blade.php
@@ -48,7 +48,7 @@ $jVersionHelper      = new JoomlaVersion($this->getContainer());
     </sup>
 @elseif($version->isBeta())
     <sup>
-            <span class="badge bg-warning">
+            <span class="badge text-bg-warning">
                 <span aria-hidden="true">@lang('PANOPTICON_MAIN_SITES_LBL_BETA_SHORT')</span>
                 <span class="visually-hidden">@lang('PANOPTICON_MAIN_SITES_LBL_BETA_LONG')</span>
             </span>

--- a/ViewTemplates/Setup/precheck.php
+++ b/ViewTemplates/Setup/precheck.php
@@ -231,7 +231,7 @@ $this->getContainer()->application->getDocument()->addScriptDeclaration($js);
 							</span>
 								</td>
 								<td>
-							<span class="badge <?= $option['current'] == $option['recommended'] ? 'bg-success' : 'bg-warning' ?>">
+							<span class="badge <?= $option['current'] == $option['recommended'] ? 'bg-success' : 'text-bg-warning' ?>">
 								<span class="fa <?= $option['current'] == $option['recommended'] ? 'fa-check-circle' : 'fa-times-circle' ?>" aria-hidden="true"></span>
 								<?= $option['current'] ? $this->getLanguage()->text('AWF_YES') : $this->getLanguage()->text('AWF_NO') ?>
 							</span>

--- a/ViewTemplates/Sites/item_extensions.blade.php
+++ b/ViewTemplates/Sites/item_extensions.blade.php
@@ -28,7 +28,7 @@ $hasError            = !empty($lastError);
 @section('extUpdateBadgeHasUpdates')
     @if ($extensionsQuickInfo->update > 0)
         <sup>
-                    <span class="badge bg-warning"
+                    <span class="badge text-bg-warning"
                           data-bs-toggle="tooltip" data-bs-placement="bottom"
                           data-bs-title="@plural('PANOPTICON_SITE_LBL_EXTENSIONS_HEAD_UPDATES_N', $extensionsQuickInfo->update)"
                     >
@@ -43,7 +43,7 @@ $hasError            = !empty($lastError);
 @section('extUpdateBadgeHasMissingSites')
     @if ($extensionsQuickInfo->site > 0)
         <sup>
-                    <span class="badge bg-warning"
+                    <span class="badge text-bg-warning"
                           data-bs-toggle="tooltip" data-bs-placement="bottom"
                           data-bs-title="@plural('PANOPTICON_SITE_LBL_EXTENSIONS_HEAD_UPDATESITES_N', $extensionsQuickInfo->site)"
                     >
@@ -452,7 +452,7 @@ $hasError            = !empty($lastError);
 
                                 @if ($noUpdateSite)
                                     <a href="https://github.com/akeeba/panopticon/wiki/Extensions-Without-Update-Sites" target="_blank">
-                                        <span class="badge bg-warning">
+                                        <span class="badge text-bg-warning">
                                             <span class="fa fa-globe" aria-hidden="true"></span>
                                             @lang('PANOPTICON_SITE_LBL_EXTENSIONS_UPDATESITE_MISSING')
                                         </span>

--- a/ViewTemplates/Sites/item_server.blade.php
+++ b/ViewTemplates/Sites/item_server.blade.php
@@ -153,7 +153,7 @@ $freeDb     = !empty($serverInfo->dbDisk->free ?? 0)
                          data-bs-toggle="tooltip" data-bs-placement="bottom"
                          data-bs-title="@lang('PANOPTICON_SITE_LBL_SERVER_CPU_TYPE_IOWAIT'): {{{ sprintf('%0.2f', floatval($serverInfo->cpuUsage->iowait)) }}}%"
                     >
-                        <div class="progress-bar bg-warning"></div>
+                        <div class="progress-bar text-bg-warning"></div>
                     </div>
 
                     <div class="progress" role="progressbar"
@@ -250,7 +250,7 @@ $freeDb     = !empty($serverInfo->dbDisk->free ?? 0)
 
 		if ($usedPercent > 70)
         {
-            $class = 'bg-warning';
+            $class = 'text-bg-warning';
         }
 
 		if ($usedPercent >= 85)

--- a/ViewTemplates/Sysconfig/default_email.blade.php
+++ b/ViewTemplates/Sysconfig/default_email.blade.php
@@ -199,7 +199,7 @@ $user   = $this->container->userManager->getUser();
 </div>
 
 <div class="card border-warning">
-    <h3 class="card-header h4 bg-warning text-dark">
+    <h3 class="card-header h4 text-bg-warning">
         @lang('PANOPTICON_SYSCONFIG_LBL_SUBHEAD_EMAIL_TEST')
     </h3>
     <div class="card-body">

--- a/templates/default/index.php
+++ b/templates/default/index.php
@@ -99,7 +99,7 @@ $importMap     = TemplateHelper::getImportMapAsJson();
 							</sup>
 						<?php elseif ($versionTag === Version::TAG_TYPE_BETA): ?>
 							<sup>
-								<span class="badge bg-warning"><?= ucfirst($versionTag) ?></span>
+								<span class="badge text-bg-warning"><?= ucfirst($versionTag) ?></span>
 							</sup>
 						<?php elseif ($versionTag === Version::TAG_TYPE_RELEASE_CANDIDATE): ?>
 							<sup>
@@ -122,7 +122,7 @@ $importMap     = TemplateHelper::getImportMapAsJson();
 							</sup>
 						<?php elseif ($versionTag === Version::TAG_TYPE_BETA): ?>
 							<sup>
-								<span class="badge bg-warning"><?= ucfirst($versionTag) ?></span>
+								<span class="badge text-bg-warning"><?= ucfirst($versionTag) ?></span>
 							</sup>
 						<?php elseif ($versionTag === Version::TAG_TYPE_RELEASE_CANDIDATE): ?>
 							<sup>


### PR DESCRIPTION
This is your call but bg-warning produces white text on the warning background which fails the a11y contrast.

There is a new(ish) bs class of text-bg-warning which "guarantees" accessibile contrast which in this case becomes black text. I think its a change worth making but your decision.

![image](https://github.com/akeeba/panopticon/assets/1296369/1a268f0a-e26a-4485-bc03-0760049a9228)

**NOT in this PR** but similar is the use of the warning color in the sites overview. That also fails but the only option to fix that would be to use the styling from the dashboard. Afain your choice.

![image](https://github.com/akeeba/panopticon/assets/1296369/e6ecefe2-2e7b-4521-8f5a-9d3fe60cc01f)
![image](https://github.com/akeeba/panopticon/assets/1296369/24f8c5d4-9a1f-41eb-8b07-fce437510ab4)

Think about it and let me know