### PR TITLE
Hide favicon on mobile

### DIFF
--- a/ViewTemplates/Main/dashboard.blade.php
+++ b/ViewTemplates/Main/dashboard.blade.php
@@ -199,7 +199,7 @@ defined('AKEEBA') || die;
                     </div>
 
                     <div class="d-flex flex-row gap-2 align-items-start gap-3">
-                        <div class="flex-shrink-1"
+                        <div class="flex-shrink-1 d-none d-md-block"
                              v-if="site.favicon"
                         >
                             <img :src="site.favicon" alt=""


### PR DESCRIPTION
On all views except for the dashboard the favicon is not displayed on mobile views. This PR extends the same to the dashboard. Consitency etc

### Before
![image](https://github.com/akeeba/panopticon/assets/1296369/f9bfcb36-ab41-461a-bb6b-ca62e01676b6)

### After
![image](https://github.com/akeeba/panopticon/assets/1296369/02387efc-ee10-4d87-b26c-fd117ac9b62f)
