### PR TITLE
Language Select

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -323,7 +323,7 @@ class Application extends AWFApplication
 				'url'         => $langUrl($code),
 				'permissions' => [],
 				'name'        => 'set_lang_' . $code,
-				'title'       => $langName,
+				'title'       => '<span lang="' . $code . '">' . $langName . '</span>',
 			];
 		}
 


### PR DESCRIPTION
The aim of this PR is to ensure that assistive technology understands that the items in the language select menu are in the native language. This ensures that a screen reader will for example use a french voice for Francais

I have followed the advice from https://designsystem.digital.gov/components/language-selector/ as a reference

I have used the full code (fr-FR) only because I didn't know how to get just the fr. The advice from the w3c is to use the shortest possible ie only use fr-Fr if you also have fr-CA otherwise just fr. But using fr-FR is perfectly valid so in the absence of other code that's what I went with.

_PS the emoji are accessible because they are announced as the full name although that also means you will hear Francais, Francais France_