### PR TITLE
Joomla update disables all site tasks

### DIFF
--- a/src/Task/JoomlaUpdateDirector.php
+++ b/src/Task/JoomlaUpdateDirector.php
@@ -168,7 +168,7 @@ class JoomlaUpdateDirector extends AbstractCallback
 			$query = $db->getQuery(true)
 				->update($db->quoteName('#__tasks'))
 				->set($db->quoteName('enabled') . ' = 0')
-                ->where($db->quoteName('type').' like '.$db->quote('joomlaupdate'))
+                ->where($db->quoteName('type').' like '.$db->quote('joomlaupdate')) 
 				->where($db->quoteName('site_id') . ' IN(' . implode(',', $siteIDs) . ')');
 			$db->setQuery($query)->execute();
 		}

--- a/src/Task/JoomlaUpdateDirector.php
+++ b/src/Task/JoomlaUpdateDirector.php
@@ -164,7 +164,7 @@ class JoomlaUpdateDirector extends AbstractCallback
 				->where($db->quoteName('id') . ' IN(' . implode(',', $siteIDs) . ')');
 			$db->setQuery($query)->execute();
 
-			// Disable all pending 'joomlaupdate' tasks for these sites
+			// Disable all pending 'joomlaupdate' tasks for these sites.
 			$query = $db->getQuery(true)
 				->update($db->quoteName('#__tasks'))
 				->set($db->quoteName('enabled') . ' = 0')

--- a/src/Task/JoomlaUpdateDirector.php
+++ b/src/Task/JoomlaUpdateDirector.php
@@ -164,7 +164,7 @@ class JoomlaUpdateDirector extends AbstractCallback
 				->where($db->quoteName('id') . ' IN(' . implode(',', $siteIDs) . ')');
 			$db->setQuery($query)->execute();
 
-			// Disable all pending 'joomlaupdate' tasks for these sites.
+			// Disable all pending 'joomlaupdate' tasks for these sites
 			$query = $db->getQuery(true)
 				->update($db->quoteName('#__tasks'))
 				->set($db->quoteName('enabled') . ' = 0')

--- a/src/Task/JoomlaUpdateDirector.php
+++ b/src/Task/JoomlaUpdateDirector.php
@@ -168,6 +168,7 @@ class JoomlaUpdateDirector extends AbstractCallback
 			$query = $db->getQuery(true)
 				->update($db->quoteName('#__tasks'))
 				->set($db->quoteName('enabled') . ' = 0')
+                ->where($db->quoteName('type').' like '.$db->quote('joomlaupdate'))
 				->where($db->quoteName('site_id') . ' IN(' . implode(',', $siteIDs) . ')');
 			$db->setQuery($query)->execute();
 		}

--- a/src/Task/JoomlaUpdateDirector.php
+++ b/src/Task/JoomlaUpdateDirector.php
@@ -168,7 +168,7 @@ class JoomlaUpdateDirector extends AbstractCallback
 			$query = $db->getQuery(true)
 				->update($db->quoteName('#__tasks'))
 				->set($db->quoteName('enabled') . ' = 0')
-                ->where($db->quoteName('type').' like '.$db->quote('joomlaupdate')) 
+                ->where($db->quoteName('type').' like '.$db->quote('joomlaupdate'))
 				->where($db->quoteName('site_id') . ' IN(' . implode(',', $siteIDs) . ')');
 			$db->setQuery($query)->execute();
 		}


### PR DESCRIPTION
fix issue #581 

On Joomla update, all site task are disabled.

This PR only disables joomlaupdate task from the current updated site.
