### PR TITLE
remove control extensions names during saving updates configuration

### DIFF
--- a/src/Model/Sysconfig.php
+++ b/src/Model/Sysconfig.php
@@ -207,13 +207,6 @@ class Sysconfig extends Model
 			fn($v) => is_string($v) && in_array($v, ['', 'email', 'none', 'major', 'minor', 'patch'])
 		);
 
-		// Filter the data keys
-		$data = array_filter(
-			$data,
-			[$this, 'isvalidShortname'],
-			ARRAY_FILTER_USE_KEY
-		);
-
 		if (empty($data))
 		{
 			return;
@@ -283,52 +276,6 @@ class Sysconfig extends Model
 			'template' => ($client_id === 0 ? 'atpl_' : 'tpl_') . $element,
 			default => null,
 		};
-	}
-
-	/**
-	 * Is this a valid short name for a Joomla! extension?
-	 *
-	 * @param   string  $shortname  The shortname to check.
-	 *
-	 * @return  bool
-	 */
-	public function isvalidShortname(string $shortname): bool
-	{
-		if (!str_contains($shortname, '_'))
-		{
-			return false;
-		}
-
-		$parts = explode('_', $shortname, 3);
-
-		if (!in_array($parts[0], ['pkg', 'com', 'plg', 'amod', 'mod', 'file', 'lib', 'tpl', 'atpl']))
-		{
-			return false;
-		}
-
-		$noEmptyparts = array_reduce(
-			$parts,
-			fn(bool $carry, $item) => $carry && (is_string($item) && !empty($item)),
-			true
-		);
-
-		switch ($parts[0])
-		{
-			case 'pkg':
-			case 'com':
-			case 'file':
-			case 'lib':
-			case 'mod':
-			case 'amod':
-			case 'tpl':
-			case 'atpl':
-				return count($parts) >= 2 && $noEmptyparts;
-
-			case 'plg':
-				return count($parts) >= 3 && $noEmptyparts;
-		}
-
-		return false;
 	}
 
 	public function getUptimeOptions()


### PR DESCRIPTION
Removal of the control on extension names during the saving of the update configuration. This control is not necessary because it does not adhere to a Joomla standard for naming extensions.
Joomla discussion on this topic : https://github.com/joomla/joomla-cms/discussions/43653

Before

The value set for an extension was not taken into account during the saving process.

After

The configuration is correctly saved. The updates work

![image](https://github.com/akeeba/panopticon/assets/5129879/35173f09-178f-4d4a-9e9f-e4498f72668c)
