### PR TITLE
Update panopticon.pot / 3 small typos (missing ".")

### DIFF
--- a/languages/panopticon.pot
+++ b/languages/panopticon.pot
@@ -7344,17 +7344,17 @@ msgstr ""
 
 #, phpformat
 msgctxt "PANOPTICON_LBL_USER_SAVED"
-msgid "The user account has been saved"
+msgid "The user account has been saved."
 msgstr ""
 
 #, phpformat
 msgctxt "PANOPTICON_LBL_USER_DELETED"
-msgid "The user account has been deleted"
+msgid "The user account has been deleted."
 msgstr ""
 
 #, phpformat
 msgctxt "PANOPTICON_LBL_USER_COPIED"
-msgid "The user account has been copied"
+msgid "The user account has been copied."
 msgstr ""
 
 #, phpformat
@@ -9846,4 +9846,3 @@ msgstr ""
 msgctxt "PANOPTICON_SYSERROR_LEAKED_PASSWORD"
 msgid "The password you are trying to use is present in online password leaks, making it very easy for hackers to guess this is what you are using. Please use a different password."
 msgstr ""
-


### PR DESCRIPTION
With these 3 changes in the user area, a period "." was added to the end of the outputs added because there is also a period "." in the group area and the other associated outputs is present. It fits together better that way.