### PR TITLE
Add composite indexes on #__tasks for task runner performance

### DIFF
--- a/src/schema/mysql.xml
+++ b/src/schema/mysql.xml
@@ -109,7 +109,9 @@ CREATE TABLE IF NOT EXISTS `#__tasks`
     `locked`          DATETIME        NULL,
     `priority`        INT             NOT NULL DEFAULT 0,
     FOREIGN KEY `#__tasks_sites` (`site_id`) REFERENCES `#__sites` (`id`) ON DELETE CASCADE,
-    PRIMARY KEY (`id`)
+    PRIMARY KEY (`id`),
+    INDEX `idx_tasks_enabled_next_priority` (`enabled`, `next_execution`, `priority`),
+    INDEX `idx_tasks_enabled_exit_next` (`enabled`, `last_exit_code`, `next_execution`)
 )
     DEFAULT COLLATE utf8mb4_unicode_ci
     ENGINE = InnoDB;
@@ -129,6 +131,22 @@ ALTER TABLE `#__tasks`
             <query><![CDATA[
 ALTER TABLE `#__tasks`
     MODIFY COLUMN `storage` JSON;
+]]></query>
+        </action>
+
+        <action table="#__tasks" canfail="1">
+            <condition type="index" operator="not"><![CDATA[idx_tasks_enabled_next_priority]]></condition>
+            <query><![CDATA[
+ALTER TABLE `#__tasks`
+    ADD INDEX `idx_tasks_enabled_next_priority` (`enabled`, `next_execution`, `priority`);
+]]></query>
+        </action>
+
+        <action table="#__tasks" canfail="1">
+            <condition type="index" operator="not"><![CDATA[idx_tasks_enabled_exit_next]]></condition>
+            <query><![CDATA[
+ALTER TABLE `#__tasks`
+    ADD INDEX `idx_tasks_enabled_exit_next` (`enabled`, `last_exit_code`, `next_execution`);
 ]]></query>
         </action>
 


### PR DESCRIPTION
Without indexes on (enabled, next_execution, priority) and (enabled, last_exit_code, next_execution), the task runner query performs a full table scan on every CRON tick. On deployments with ~1500 sites (~3400+ tasks), this caused 9ms full table scans (3402 rows examined) instead of sub-millisecond index lookups (20 rows).

Measured improvement: 30x faster query, 170x fewer rows examined.

Includes migration actions for existing installations via database:update.