### PR TITLE
Update AkeebaBackupIntegrationTrait.php

### DIFF
--- a/src/Model/Trait/AkeebaBackupIntegrationTrait.php
+++ b/src/Model/Trait/AkeebaBackupIntegrationTrait.php
@@ -210,7 +210,7 @@ trait AkeebaBackupIntegrationTrait
 
 			if (empty($endpoints))
 			{
-				throw new AkeebaBackupIsNotPro();
+				$throwThis ??= new AkeebaBackupIsNotPro();
 			}
 
 			foreach ($endpoints as $someEndpoint)


### PR DESCRIPTION
Hi,

when trying to add Joomla 3 site without Akeeba Backup Pro, saving the site always fails. Only the "You do not seem to have Akeeba Backup Professional installed." error is displayed. Also, on already added J3 site this error occurs when trying to resynchronize Akeeba Backup, instead showing, that only Core or no Akeeba Backup is installed.

Testing instructions - try to add Joomla 3 website without Akeeba Backup, or with Core version.
Expected result - site added
Actual result - "You do not seem to have Akeeba Backup Professional installed." error

Further thoughts - as the AkeebaBackupIntegrationTrait::testAkeebaBackupConnection function has parameter $throw, IMO exception should be thrown only based on this parameter. Please check this proposal, if it does not break any other logic on other place.

Thank you

Pavel