### PR TITLE
QueueItem::getSiteId could be null

### DIFF
--- a/src/Task/SendMail.php
+++ b/src/Task/SendMail.php
@@ -174,11 +174,11 @@ class SendMail extends AbstractCallback
 
 				$this->sendLanguageBatches(
 					$recipientsWithAttach, $template, $defaultLanguage,
-					$variables, $variablesByLang, $attachment, $queueItem->getSiteId()
+					$variables, $variablesByLang, $attachment, $queueItem->getSiteId() ?: 0
 				);
 				$this->sendLanguageBatches(
 					$recipientsWithoutAttach, $template, $defaultLanguage,
-					$variables, $variablesByLang, null, $queueItem->getSiteId()
+					$variables, $variablesByLang, null, $queueItem->getSiteId() ?: 0
 				);
 			}
 			else
@@ -206,7 +206,7 @@ class SendMail extends AbstractCallback
 
 				$this->sendLanguageBatches(
 					$recipientsByLanguage, $template, $defaultLanguage,
-					$variables, $variablesByLang, $attachment, $queueItem->getSiteId()
+					$variables, $variablesByLang, $attachment, $queueItem->getSiteId() ?: 0
 				);
 			}
 


### PR DESCRIPTION
Installing extension to multiple sites should send an email, but actually no email is sent.

Steps to reproduce:
- open "Install extensions" page, select multiple sites (5 in my case)
- choose some extension (used local file in my case)
- execute the task

Expected result: Email with installation summary should arrive

Actual result: no email arrives, in tasks log following error is displayed
```
Akeeba\Panopticon\Task\SendMail::sendLanguageBatches(): Argument #7 ($siteId) must be of type int, null given, called in ../src/Task/SendMail.php on line 207

../src/Task/SendMail.php::241
#0 ../src/Task/SendMail.php(207): Akeeba\Panopticon\Task\SendMail->sendLanguageBatches()
#1 ../src/Task/Trait/EmailSendingTrait.php(69): Akeeba\Panopticon\Task\SendMail->__invoke()
#2 ../src/Task/ExtensionInstall.php(535): Akeeba\Panopticon\Task\ExtensionInstall->enqueueEmail()
#3 ../src/Task/ExtensionInstall.php(61): Akeeba\Panopticon\Task\ExtensionInstall->finalize()
#4 ../src/Model/Task.php(596): Akeeba\Panopticon\Task\ExtensionInstall->__invoke()
#5 ../src/CliCommand/TaskRun.php(88): Akeeba\Panopticon\Model\Task->runNextTask()
#6 ../vendor/symfony/console/Command/Command.php(326): Akeeba\Panopticon\CliCommand\TaskRun->execute()
#7 ../vendor/symfony/console/Application.php(1098): Symfony\Component\Console\Command\Command->run()
#8 ../vendor/symfony/console/Application.php(324): Symfony\Component\Console\Application->doRunCommand()
#9 ../vendor/symfony/console/Application.php(175): Symfony\Component\Console\Application->doRun()
#10 ../cli/panopticon.php(82): Symfony\Component\Console\Application->run()
#11 ../upg/cli/panopticon.php(83): {closure:/www/hosting/n3t.cz/upg/cli/panopticon.php:23}()
#12 {main}
```

Same error appeared also in selfupdatefinder Task.

The reason is that Task\SendMail::sendLanguageBatches() parameter $siteId is not nullable, but is called with nullable argument (QueueItem::getSiteId).

Proposed change just changes nulls to zeros, either the parameter is used just for logs in sendLanguageBatches function.

Thank you for considering this PR, 

Pavel