### PR TITLE
Fix log viewer fatal error in non-English interface languages

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -18,6 +18,7 @@ Akeeba Panopticon 2.2.1
 # [HIGH] Refactored code to avoid false positives in some anti-malware scanners e.g. Immunify360
 # [MEDIUM] Web Push notifications were not sent in each recipient's own language as intended [gh-1027]
 # [MEDIUM] Scheduled update summary emails re-sent duplicate notifications on every run
+# [HIGH] Log viewer showed a blank or error page when the interface language was not English [gh-1035]
 # [LOW] Completed one-shot tasks (e.g. extension install) were never deleted [gh-1034]
 # [LOW] Log viewer dropped the first line of any log read in full, showing an empty table for a one-line log [gh-1036]
 

--- a/ViewTemplates/Main/site_php.blade.php
+++ b/ViewTemplates/Main/site_php.blade.php
@@ -62,7 +62,7 @@ $isLatest      = version_compare($php, $latestVersion, 'ge');
 		{
 			$eolDate = $this->container->dateFactory(
 				$phpVersion->getVersionInformation($php)?->dates?->eol?->format(DATE_RFC3339) ?? '2000-01-01 00:00:00'
-			)->format($this->getLanguage()->text('DATE_FORMAT_LC3'));
+			)->format($this->getLanguage()->text('DATE_FORMAT_LC3'), false, true);
 		}
 		catch (Throwable)
 		{
@@ -83,7 +83,7 @@ $isLatest      = version_compare($php, $latestVersion, 'ge');
 		{
 			$eolDate = $this->container->dateFactory(
 				$phpVersion->getVersionInformation($php)?->dates?->eol?->format(DATE_RFC3339) ?? '2000-01-01 00:00:00'
-			)->format($this->getLanguage()->text('DATE_FORMAT_LC3'));
+			)->format($this->getLanguage()->text('DATE_FORMAT_LC3'), false, true);
 		}
 		catch (Throwable)
 		{

--- a/composer.lock
+++ b/composer.lock
@@ -12,12 +12,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/akeeba/awf.git",
-                "reference": "f0ece56b381179e8ff0db5abcf4e0bf8652ccd64"
+                "reference": "fac54f4a6aabbf874a5119e9826201259e864c3c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/akeeba/awf/zipball/f0ece56b381179e8ff0db5abcf4e0bf8652ccd64",
-                "reference": "f0ece56b381179e8ff0db5abcf4e0bf8652ccd64",
+                "url": "https://api.github.com/repos/akeeba/awf/zipball/fac54f4a6aabbf874a5119e9826201259e864c3c",
+                "reference": "fac54f4a6aabbf874a5119e9826201259e864c3c",
                 "shasum": ""
             },
             "require": {
@@ -70,7 +70,7 @@
                 "issues": "https://github.com/akeeba/awf/issues",
                 "source": "https://github.com/akeeba/awf/tree/development"
             },
-            "time": "2026-07-13T21:50:02+00:00"
+            "time": "2026-07-23T18:21:59+00:00"
         },
         {
             "name": "akeeba/json-backup-api",

--- a/src/Task/AkeebaBackup.php
+++ b/src/Task/AkeebaBackup.php
@@ -47,14 +47,17 @@ class AkeebaBackup extends AbstractCallback
 		// Replace the variables in the description and comment
 		$now          = $this->container->dateFactory();
 		$replacements = [
-			'{DATE_FORMAT_LC}'  => $now->format($this->getLanguage()->text('DATE_FORMAT_LC')),
-			'{DATE_FORMAT_LC1}' => $now->format($this->getLanguage()->text('DATE_FORMAT_LC1')),
-			'{DATE_FORMAT_LC2}' => $now->format($this->getLanguage()->text('DATE_FORMAT_LC2')),
-			'{DATE_FORMAT_LC3}' => $now->format($this->getLanguage()->text('DATE_FORMAT_LC3')),
-			'{DATE_FORMAT_LC4}' => $now->format($this->getLanguage()->text('DATE_FORMAT_LC4')),
-			'{DATE_FORMAT_LC5}' => $now->format($this->getLanguage()->text('DATE_FORMAT_LC5')),
-			'{DATE_FORMAT_LC6}' => $now->format($this->getLanguage()->text('DATE_FORMAT_LC6')),
-			'{DATE_FORMAT_LC7}' => $now->format($this->getLanguage()->text('DATE_FORMAT_LC7')),
+			// The DATE_FORMAT_LCx strings are translatable, so any of them may contain localised day/month tokens
+			// in a given language. Pass $translate = true so these human-facing dates stay localised (AWF's
+			// Date::format() no longer translates by default).
+			'{DATE_FORMAT_LC}'  => $now->format($this->getLanguage()->text('DATE_FORMAT_LC'), false, true),
+			'{DATE_FORMAT_LC1}' => $now->format($this->getLanguage()->text('DATE_FORMAT_LC1'), false, true),
+			'{DATE_FORMAT_LC2}' => $now->format($this->getLanguage()->text('DATE_FORMAT_LC2'), false, true),
+			'{DATE_FORMAT_LC3}' => $now->format($this->getLanguage()->text('DATE_FORMAT_LC3'), false, true),
+			'{DATE_FORMAT_LC4}' => $now->format($this->getLanguage()->text('DATE_FORMAT_LC4'), false, true),
+			'{DATE_FORMAT_LC5}' => $now->format($this->getLanguage()->text('DATE_FORMAT_LC5'), false, true),
+			'{DATE_FORMAT_LC6}' => $now->format($this->getLanguage()->text('DATE_FORMAT_LC6'), false, true),
+			'{DATE_FORMAT_LC7}' => $now->format($this->getLanguage()->text('DATE_FORMAT_LC7'), false, true),
 		];
 		$description  = str_replace(array_keys($replacements), array_values($replacements), $description);
 		$comment      = str_replace(array_keys($replacements), array_values($replacements), $comment);


### PR DESCRIPTION
Fixes #1035.

## Problem

The Log viewer threw a fatal error and rendered a blank/error page for any log file with entries whenever the interface language was not English (e.g. Italian). With debug enabled the visible symptom was a misleading `TypeError: count(): Argument #1 ($value) must be of type Countable|array, null given`.

## Root cause (in AWF)

`Awf\Date\Date::format()` defaulted its `$translate` parameter to `true`, localising the `D`/`l`/`M`/`F` day/month tokens for every call — including machine-readable formats. `ViewTemplates/Logs/item_table.blade.php` formats the log timestamp with `DATE_RSS`, so it produced a *localised* RFC-822 string (e.g. "Mer, 22 Lug 2026…"). That string is then re-parsed by the `basic.date` HTML helper, which fails because PHP's date parser only understands English month/day names. The exception was swallowed by `Awf\Mvc\View::loadTemplate()`'s layout-fallback loop, which fell back to the `default` layout whose `count($this->items)` then fatally errored (that read path only populates `$this->logLines`).

## Fix

The real fix lives in AWF — akeeba/awf#15 / akeeba/awf@fac54f4 — making date-token translation **opt-in** (default `false`), matching native `DateTime::format()`. This PR bumps the `akeeba/awf` dependency to pick it up.

Because a couple of Panopticon display sites relied on the old translate-by-default behaviour, they now opt back into translation explicitly so their dates stay localised (no regression):

- `src/Task/AkeebaBackup.php` — the `{DATE_FORMAT_LCx}` placeholders in backup descriptions/comments.
- `ViewTemplates/Main/site_php.blade.php` — the dashboard PHP end-of-life dates.

## Changes

- `composer.lock` — `akeeba/awf` → `fac54f4`
- `src/Task/AkeebaBackup.php`, `ViewTemplates/Main/site_php.blade.php` — explicit `$translate = true` at localised-display sites
- `CHANGELOG`

The AWF change is covered by a new unit test; the full AWF Unit suite (4241 tests) is green.